### PR TITLE
Add global theme toggle

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,8 +1,52 @@
 @import "tailwindcss";
 
+
 :root {
   --background: #070a14;
-  --foreground: #f8fafc;
+  --foreground: #e2e8f0;
+  --muted-foreground: #cbd5e1;
+  --border: #1f2937;
+  --card-background: rgba(15, 23, 42, 0.7);
+  --card-border: #1e293b;
+  --chip-background: #1f2937;
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-faint: rgba(99, 102, 241, 0.12);
+  --success: #22c55e;
+  --nav-surface: rgba(7, 10, 20, 0.7);
+  --button-text-on-primary: #f8fafc;
+}
+
+.light-theme {
+  --background: #f8fafc;
+  --foreground: #0f172a;
+  --muted-foreground: #475569;
+  --border: #e2e8f0;
+  --card-background: rgba(255, 255, 255, 0.85);
+  --card-border: #e2e8f0;
+  --chip-background: #e2e8f0;
+  --accent: #4f46e5;
+  --accent-strong: #4338ca;
+  --accent-faint: rgba(79, 70, 229, 0.12);
+  --success: #16a34a;
+  --nav-surface: rgba(255, 255, 255, 0.8);
+  --button-text-on-primary: #eef2ff;
+}
+
+.dark-theme {
+  --background: #070a14;
+  --foreground: #e2e8f0;
+  --muted-foreground: #cbd5e1;
+  --border: #1f2937;
+  --card-background: rgba(15, 23, 42, 0.7);
+  --card-border: #1e293b;
+  --chip-background: #1f2937;
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-faint: rgba(99, 102, 241, 0.12);
+  --success: #22c55e;
+  --nav-surface: rgba(7, 10, 20, 0.7);
+  --button-text-on-primary: #f8fafc;
 }
 
 @theme inline {
@@ -10,13 +54,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #050710;
-    --foreground: #e5e7eb;
-  }
 }
 
 body {
@@ -27,6 +64,93 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, -apple-system, sans-serif;
   min-height: 100vh;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.page-shell {
+  color: var(--foreground);
+}
+
+.nav-surface {
+  background-color: var(--nav-surface);
+  border-color: var(--border);
+}
+
+.card-surface {
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  color: var(--foreground);
+}
+
+.border-muted {
+  border-color: var(--border);
+}
+
+.text-muted {
+  color: var(--muted-foreground);
+}
+
+.text-accent {
+  color: var(--accent);
+}
+
+.text-success {
+  color: var(--success);
+}
+
+.chip {
+  background: var(--chip-background);
+  color: var(--foreground);
+}
+
+.btn-base {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  transition: all 200ms ease;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--button-text-on-primary);
+}
+
+.btn-primary:hover {
+  background: var(--accent-strong);
+}
+
+.btn-primary:disabled {
+  background: var(--accent-faint);
+  color: var(--muted-foreground);
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: var(--card-background);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+  background: var(--accent-faint);
+}
+
+.btn-outline {
+  border: 2px solid var(--accent);
+  color: var(--accent);
+}
+
+.btn-outline:hover {
+  background: var(--accent-faint);
+}
+
+.btn-outline:disabled {
+  border-color: var(--accent-faint);
+  color: var(--accent-faint);
+  cursor: not-allowed;
 }
 
 @keyframes marquee {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth-context";
 import { I18nProvider } from "@/lib/i18n-context";
+import { ThemeProvider } from "@/lib/theme-context";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,9 +31,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <I18nProvider>
-          <AuthProvider>{children}</AuthProvider>
-        </I18nProvider>
+        <ThemeProvider>
+          <I18nProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </I18nProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import Link from "next/link";
 import { Button } from "@/components/Button";
 import { Card } from "@/components/Card";
 import api, { LanguageOption } from "@/lib/api";
 import { useTranslation } from "@/lib/i18n-context";
+import { useTheme } from "@/lib/theme-context";
 
 export default function Home() {
   const { t, locale, setLocale } = useTranslation();
+  const { theme, toggleTheme } = useTheme();
   const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>([
     { code: "en", label: "English", direction: "ltr" },
     { code: "de", label: "Deutsch (German)", direction: "ltr" },
@@ -85,21 +86,38 @@ export default function Home() {
   ];
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
+    <div className="page-shell min-h-screen">
       {/* Header */}
-      <header className="border-b border-slate-800">
+      <header className="border-b border-muted backdrop-blur nav-surface">
         <div className="container mx-auto px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <img src="/logo.png" alt="EasyBewerbung" className="w-8 h-8 rounded-lg" />
             <span className="text-xl font-bold">{t("common.appName")}</span>
           </div>
           <div className="flex gap-3 items-center">
-            <div className="relative">
-              <label className="text-sm text-slate-400 mr-2">{t("common.language")}:</label>
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="btn-base btn-secondary flex items-center gap-2"
+              aria-pressed={theme === "light"}
+            >
+              <span aria-hidden>{theme === "light" ? "🌙" : "☀️"}</span>
+              <span className="text-sm">
+                {theme === "light" ? t("common.darkMode") : t("common.lightMode")}
+              </span>
+            </button>
+            <div className="relative flex items-center">
+              <label className="text-sm text-muted mr-2">{t("common.language")}:</label>
               <select
                 value={locale}
                 onChange={(e) => handleLanguageChange(e.target.value)}
-                className="px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2"
+                style={{
+                  background: "var(--card-background)",
+                  color: "var(--foreground)",
+                  borderColor: "var(--border)",
+                  boxShadow: "none",
+                }}
               >
                 {languageOptions.map((lang) => (
                   <option key={lang.code} value={lang.code}>
@@ -127,10 +145,10 @@ export default function Home() {
               {t("home.titleHighlight")}
             </span>
           </h1>
-          <p className="text-xl text-slate-300">
+          <p className="text-xl text-muted">
             {t("home.subtitle")}
           </p>
-          <p className="text-lg text-emerald-400">
+          <p className="text-lg text-success">
             {t("home.availableLanguages")}
           </p>
           <div className="flex gap-4 justify-center pt-4">
@@ -154,7 +172,7 @@ export default function Home() {
             <Card key={index}>
               <div className="text-4xl mb-4">{feature.icon}</div>
               <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
-              <p className="text-slate-400">{feature.description}</p>
+              <p className="text-muted">{feature.description}</p>
             </Card>
           ))}
         </div>
@@ -167,14 +185,14 @@ export default function Home() {
             {t("home.languageSection")}
           </h2>
           <Card>
-            <p className="text-slate-300 text-center mb-6">
+            <p className="text-muted text-center mb-6">
               {t("home.languageDescription")}
             </p>
             <div className="flex flex-wrap gap-2 justify-center">
               {languages.map((lang, index) => (
                 <span
                   key={index}
-                  className="px-3 py-1 rounded-full bg-slate-700 text-sm text-slate-200"
+                  className="chip px-3 py-1 rounded-full text-sm"
                 >
                   {lang}
                 </span>
@@ -187,11 +205,11 @@ export default function Home() {
       {/* Swiss RAV Section */}
       <section className="container mx-auto px-6 py-16">
         <div className="max-w-2xl mx-auto text-center">
-          <Card className="bg-emerald-900/20 border-emerald-700">
-            <h2 className="text-2xl font-bold mb-4 text-emerald-400">
+          <Card className="border-2" style={{ borderColor: "var(--success)" }}>
+            <h2 className="text-2xl font-bold mb-4 text-success">
               🇨🇭 {t("home.ravTitle")}
             </h2>
-            <p className="text-slate-300">
+            <p className="text-muted">
               {t("home.ravDescription")}
             </p>
           </Card>
@@ -204,7 +222,7 @@ export default function Home() {
           <h2 className="text-4xl font-bold">
             {t("home.ctaTitle")}
           </h2>
-          <p className="text-xl text-slate-300">
+          <p className="text-xl text-muted">
             {t("home.ctaSubtitle")}
           </p>
           <Button href="/register" variant="primary" className="text-lg">
@@ -214,8 +232,8 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-slate-800 py-8">
-        <div className="container mx-auto px-6 text-center text-slate-400">
+      <footer className="border-t border-muted py-8 text-muted">
+        <div className="container mx-auto px-6 text-center">
           <p>© 2025 {t("common.appName")}. {t("home.footer")}</p>
         </div>
       </footer>

--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -19,16 +19,12 @@ export function Button({
   disabled = false,
   className = "",
 }: ButtonProps) {
-  const baseStyles =
-    "inline-flex items-center justify-center px-6 py-3 rounded-lg font-semibold transition-all duration-200";
+  const baseStyles = "btn-base";
 
   const variantStyles = {
-    primary:
-      "bg-indigo-600 text-white hover:bg-indigo-700 disabled:bg-indigo-400 disabled:cursor-not-allowed",
-    secondary:
-      "bg-slate-700 text-white hover:bg-slate-600 disabled:bg-slate-500 disabled:cursor-not-allowed",
-    outline:
-      "border-2 border-indigo-600 text-indigo-600 hover:bg-indigo-50 disabled:border-indigo-300 disabled:text-indigo-300 disabled:cursor-not-allowed",
+    primary: "btn-primary",
+    secondary: "btn-secondary",
+    outline: "btn-outline",
   };
 
   const combinedClassName = `${baseStyles} ${variantStyles[variant]} ${className}`;

--- a/frontend/components/Card.tsx
+++ b/frontend/components/Card.tsx
@@ -5,9 +5,7 @@ interface CardProps {
 
 export function Card({ children, className = "" }: CardProps) {
   return (
-    <div
-      className={`rounded-xl border border-slate-700 bg-slate-800/50 p-6 backdrop-blur ${className}`}
-    >
+    <div className={`card-surface rounded-xl p-6 backdrop-blur ${className}`}>
       {children}
     </div>
   );

--- a/frontend/lib/theme-context.tsx
+++ b/frontend/lib/theme-context.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getPreferredTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+
+  const stored = window.localStorage.getItem("theme") as Theme | null;
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getPreferredTheme);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const root = document.documentElement;
+    root.classList.remove("light-theme", "dark-theme");
+    root.classList.add(theme === "light" ? "light-theme" : "dark-theme");
+    window.localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((current) => (current === "light" ? "dark" : "light")),
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+}

--- a/frontend/lib/translations/de.json
+++ b/frontend/lib/translations/de.json
@@ -2,6 +2,8 @@
   "common": {
     "appName": "EasyBewerbung",
     "language": "Sprache",
+    "lightMode": "Heller Modus",
+    "darkMode": "Dunkler Modus",
     "login": "Anmelden",
     "logout": "Abmelden",
     "getStarted": "Loslegen",

--- a/frontend/lib/translations/en.json
+++ b/frontend/lib/translations/en.json
@@ -2,6 +2,8 @@
   "common": {
     "appName": "EasyBewerbung",
     "language": "Language",
+    "lightMode": "Light mode",
+    "darkMode": "Dark mode",
     "login": "Log In",
     "logout": "Log Out",
     "getStarted": "Get Started",

--- a/frontend/lib/translations/es.json
+++ b/frontend/lib/translations/es.json
@@ -2,6 +2,8 @@
   "common": {
     "appName": "EasyBewerbung",
     "language": "Idioma",
+    "lightMode": "Modo claro",
+    "darkMode": "Modo oscuro",
     "login": "Iniciar sesión",
     "logout": "Cerrar sesión",
     "getStarted": "Comenzar",

--- a/frontend/lib/translations/fr.json
+++ b/frontend/lib/translations/fr.json
@@ -2,6 +2,8 @@
   "common": {
     "appName": "EasyBewerbung",
     "language": "Langue",
+    "lightMode": "Mode clair",
+    "darkMode": "Mode sombre",
     "login": "Se connecter",
     "logout": "Se déconnecter",
     "getStarted": "Commencer",


### PR DESCRIPTION
## Summary
- add a theme provider and header toggle to switch between light and dark modes across the site
- introduce theme-aware styling variables and update shared components and the homepage to use them
- expand translations with labels for the new theme toggle

## Testing
- npm run lint *(fails: existing lint and typing issues in the project)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203c473e008330813a94ac5aaab5e8)