### PR TITLE
fix: improve job posting display and scraping quality

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -642,8 +642,8 @@ export default function DashboardPage() {
                       {/* Job Description Preview */}
                       {app.job_description && (
                         <div className="mt-2 p-3 bg-slate-800 rounded-lg">
-                          <p className="text-sm text-slate-400 line-clamp-2">
-                            {app.job_description}
+                          <p className="text-sm text-slate-400 line-clamp-5 whitespace-pre-wrap">
+                            {app.job_description.split(/\n/).slice(0, 5).join('\n').trim()}
                           </p>
                         </div>
                       )}
@@ -702,13 +702,17 @@ export default function DashboardPage() {
                           Update Status
                         </button>
 
-                        <button
-                          onClick={() => handleDownloadJobPDF(app.id, app.job_title, app.company)}
-                          className="text-sm px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-white"
-                          title="Download job description as PDF"
-                        >
-                          📄 Download PDF
-                        </button>
+                        {app.job_offer_url && (
+                          <a
+                            href={app.job_offer_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sm px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-white inline-block"
+                            title="View original job posting"
+                          >
+                            📄 Download PDF
+                          </a>
+                        )}
                       </div>
                     </div>
                   </Card>


### PR DESCRIPTION
Addresses #15

## Frontend Improvements
- Show first 5 lines of job description instead of 2
- Add whitespace preservation to fix spacing issues
- Change PDF button to link to original job posting URL

## Backend Improvements
- Remove UI elements (nav, header, footer) before scraping
- Focus on main content area for better text extraction
- Filter out short paragraphs and common UI text
- Use double newlines between paragraphs for readability

## Testing
Please test by adding a new job posting URL to verify the improved scraping quality.

Generated with [Claude Code](https://claude.ai/code)