### PR TITLE
Generate PDF from original listing document

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -57,6 +57,7 @@ class JobOffer(Base):
     title = Column(String, nullable=True)
     company = Column(String, nullable=True)
     description = Column(Text, nullable=True)
+    original_pdf_path = Column(String, nullable=True)  # Path to original job listing PDF
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     owner = relationship("User", back_populates="job_offers")

--- a/backend/migrations/versions/20251122_03_add_original_pdf_path.py
+++ b/backend/migrations/versions/20251122_03_add_original_pdf_path.py
@@ -1,0 +1,44 @@
+"""Add original_pdf_path to job_offers table.
+
+Revision ID: 20251122_03
+Revises: 20251122_02
+Create Date: 2025-11-22
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20251122_03"
+down_revision = "20251122_02"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(inspector, table_name: str, column_name: str) -> bool:
+    columns = [col['name'] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Add original_pdf_path column to job_offers table
+    if _table_exists(inspector, "job_offers"):
+        if not _column_exists(inspector, "job_offers", "original_pdf_path"):
+            op.add_column("job_offers", sa.Column("original_pdf_path", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Remove original_pdf_path column from job_offers table
+    if _table_exists(inspector, "job_offers"):
+        if _column_exists(inspector, "job_offers", "original_pdf_path"):
+            op.drop_column("job_offers", "original_pdf_path")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ python-magic==0.4.27
 alembic==1.13.2
 pytest==8.3.3
 pytest-asyncio==0.23.8
+weasyprint==62.3

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -365,6 +365,11 @@ export default function DashboardPage() {
               <span className="px-3 py-1 rounded bg-slate-800 text-sm text-emerald-300 border border-emerald-700">
                 Credits: {user.credits}
               </span>
+              {user.is_admin && (
+                <Button onClick={() => router.push("/admin")} variant="outline">
+                  Admin
+                </Button>
+              )}
               <Button onClick={() => router.push("/settings")} variant="outline">
                 Settings
               </Button>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -463,6 +463,24 @@ class ApiClient {
 
     return response.blob();
   }
+
+  async downloadOriginalJobPDF(jobOfferId: number) {
+    const headers: HeadersInit = {};
+    if (this.token) {
+      headers["Authorization"] = `Bearer ${this.token}`;
+    }
+
+    const response = await fetch(`${this.baseUrl}/jobs/${jobOfferId}/original-pdf`, {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to download original job PDF");
+    }
+
+    return response.blob();
+  }
 }
 
 export const api = new ApiClient(API_BASE_URL);


### PR DESCRIPTION
This commit implements two features:

1. Original Job Listing PDF Archival:
   - Added original_pdf_path field to JobOffer model
   - Implemented HTML to PDF conversion using weasyprint when analyzing job offers
   - Created endpoint /jobs/{job_offer_id}/original-pdf to download original PDFs
   - Added frontend API method downloadOriginalJobPDF()
   - Original job listing HTML is now saved as PDF for archival purposes

2. Admin Dashboard Button:
   - Added admin button to dashboard header for users with is_admin=true
   - Button navigates directly to /admin page for easy admin access

Technical changes:
- Backend: Added weasyprint dependency for HTML to PDF conversion
- Backend: Extended jobs.py with save_original_pdf() helper function
- Backend: New download endpoint with security checks (user ownership)
- Database: Added migration 20251122_03 for original_pdf_path column
- Frontend: Admin button conditionally rendered based on user.is_admin
- Frontend: New API method for downloading original job PDFs