### PR TITLE
Add spontaneous application workflow

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -71,6 +71,8 @@ class Application(Base):
     job_title = Column(String, nullable=False)
     company = Column(String, nullable=False)
     job_offer_url = Column(String, nullable=True)
+    is_spontaneous = Column(Boolean, default=False)
+    opportunity_context = Column(Text, nullable=True)
     applied = Column(Boolean, default=False)
     applied_at = Column(DateTime, nullable=True)
     result = Column(String, nullable=True)

--- a/backend/migrations/versions/20251122_04_add_spontaneous_applications.py
+++ b/backend/migrations/versions/20251122_04_add_spontaneous_applications.py
@@ -1,0 +1,53 @@
+"""Add spontaneous application fields
+
+Revision ID: 20251122_04
+Revises: 20251122_03
+Create Date: 2025-11-22
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20251122_04"
+down_revision = "20251122_03"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(inspector, table_name: str, column_name: str) -> bool:
+    return column_name in [col["name"] for col in inspector.get_columns(table_name)]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if _table_exists(inspector, "applications"):
+        if not _column_exists(inspector, "applications", "is_spontaneous"):
+            op.add_column(
+                "applications",
+                sa.Column("is_spontaneous", sa.Boolean(), nullable=False, server_default=sa.false()),
+            )
+            op.alter_column("applications", "is_spontaneous", server_default=None)
+
+        if not _column_exists(inspector, "applications", "opportunity_context"):
+            op.add_column(
+                "applications",
+                sa.Column("opportunity_context", sa.Text(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if _table_exists(inspector, "applications"):
+        if _column_exists(inspector, "applications", "opportunity_context"):
+            op.drop_column("applications", "opportunity_context")
+        if _column_exists(inspector, "applications", "is_spontaneous"):
+            op.drop_column("applications", "is_spontaneous")

--- a/frontend/app/applications/[id]/page.tsx
+++ b/frontend/app/applications/[id]/page.tsx
@@ -169,6 +169,11 @@ export default function ApplicationDetailPage() {
           <Card>
             <h1 className="text-3xl font-bold mb-4">{application.job_title}</h1>
             <p className="text-xl text-slate-300 mb-4">{application.company}</p>
+            {application.is_spontaneous && (
+              <span className="inline-block mb-3 px-3 py-1 rounded bg-amber-900/50 text-amber-200 border border-amber-700 text-sm">
+                Spontaneous outreach (no posting)
+              </span>
+            )}
             {application.job_offer_url && (
               <a
                 href={application.job_offer_url}
@@ -178,6 +183,14 @@ export default function ApplicationDetailPage() {
               >
                 View Job Posting →
               </a>
+            )}
+            {(application.job_description || application.opportunity_context) && (
+              <div className="mt-4 p-4 rounded-lg bg-slate-800 border border-slate-700">
+                <h3 className="font-semibold text-slate-200 mb-2">Context</h3>
+                <p className="text-slate-300 whitespace-pre-wrap text-sm leading-relaxed">
+                  {application.job_description || application.opportunity_context}
+                </p>
+              </div>
             )}
             <div className="mt-4 flex items-center gap-4">
               <span

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -55,6 +55,8 @@ export interface Application {
   job_title: string;
   company: string;
   job_offer_url: string | null;
+  is_spontaneous: boolean;
+  opportunity_context: string | null;
   job_description: string | null;
   applied: boolean;
   applied_at: string | null;
@@ -335,6 +337,8 @@ class ApiClient {
     job_title: string;
     company: string;
     job_offer_url?: string;
+    is_spontaneous?: boolean;
+    opportunity_context?: string;
     applied?: boolean;
     applied_at?: string;
     result?: string;
@@ -345,6 +349,20 @@ class ApiClient {
     return this.request<Application>("/applications/", {
       method: "POST",
       body: JSON.stringify(data),
+    });
+  }
+
+  async createSpontaneousApplication(data: {
+    job_title: string;
+    company: string;
+    opportunity_context?: string;
+    ui_language?: string;
+    documentation_language?: string;
+    company_profile_language?: string;
+  }) {
+    return this.createApplication({
+      ...data,
+      is_spontaneous: true,
     });
   }
 


### PR DESCRIPTION
## Summary
- add spontaneous application metadata to backend schema, serialization, and migration
- allow proactive applications to use contextual prompts and appear in reports
- expose spontaneous creation flow and badges in dashboard and detail views on the frontend

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922118363a48330a02f343c815cdba4)