### PR TITLE
Add location field and format job titles with company and location

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,6 +56,7 @@ class JobOffer(Base):
     url = Column(String)
     title = Column(String, nullable=True)
     company = Column(String, nullable=True)
+    location = Column(String, nullable=True)  # Place of work / location
     description = Column(Text, nullable=True)
     original_pdf_path = Column(String, nullable=True)  # Path to original job listing PDF
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/backend/migrations/versions/20251203_01_add_location_to_job_offers.py
+++ b/backend/migrations/versions/20251203_01_add_location_to_job_offers.py
@@ -1,0 +1,44 @@
+"""Add location column to job_offers table.
+
+Revision ID: 20251203_01
+Revises: 20251122_05
+Create Date: 2025-12-03
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20251203_01"
+down_revision = "20251122_05"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(inspector, table_name: str, column_name: str) -> bool:
+    columns = [col['name'] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Add location column to job_offers table
+    if _table_exists(inspector, "job_offers"):
+        if not _column_exists(inspector, "job_offers", "location"):
+            op.add_column("job_offers", sa.Column("location", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Remove location column from job_offers table
+    if _table_exists(inspector, "job_offers"):
+        if _column_exists(inspector, "job_offers", "location"):
+            op.drop_column("job_offers", "location")


### PR DESCRIPTION
- Added location field to JobOffer model
- Created database migration for location column
- Enhanced scraping to extract location from job postings
- Format job titles as: <Job Title> - <company>, <place of work>
- Handles missing company or location gracefully

Fixes #41