### PR TITLE
Add support for apprenticeship and internship positions

### DIFF
--- a/backend/app/document_prompts.json
+++ b/backend/app/document_prompts.json
@@ -51,7 +51,16 @@
 
       "Only include travel willingness/percentage if explicitly mentioned in the original CV - DO NOT add or infer it",
       "Maintain professional tone appropriate for the industry",
-      "Keep the same level of detail as the original CV"
+      "Keep the same level of detail as the original CV",
+
+      "=== INTERNSHIP/APPRENTICESHIP APPLICATIONS ===",
+      "If the job description indicates this is an INTERNSHIP (Praktikum) or APPRENTICESHIP (Lehrstelle) application:",
+      "  - Adjust the CV to emphasize learning potential, enthusiasm, and relevant coursework/projects",
+      "  - Highlight any relevant school projects, volunteer work, or part-time experience",
+      "  - Focus on soft skills like eagerness to learn, teamwork, and reliability",
+      "  - For WMS/BMS students: emphasize commercial skills, language abilities, and IT proficiency",
+      "  - Keep the tone appropriate for a student/trainee rather than an experienced professional",
+      "  - If applying for a Praktikum, emphasize what the candidate hopes to learn and contribute"
     ],
     "output_format": "ATS-optimized single-column CV with standard sections, starting with candidate name and contact info",
     "length_guideline": "Same as original CV (typically 1-2 pages)",
@@ -177,7 +186,18 @@
       "Professional, enthusiastic, and genuine",
       "Show specific knowledge of company/role (if mentioned in job description)",
       "Quantify achievements where possible (from CV)",
-      "Keep it concise - typically 3/4 to 1 full page"
+      "Keep it concise - typically 3/4 to 1 full page",
+
+      "=== INTERNSHIP/APPRENTICESHIP APPLICATIONS ===",
+      "If the job description indicates this is an INTERNSHIP (Praktikum) or APPRENTICESHIP (Lehrstelle) application:",
+      "  - Adjust tone to reflect that the candidate is a student/trainee seeking practical experience",
+      "  - Express genuine enthusiasm for learning and contributing to the company",
+      "  - Highlight relevant coursework, school projects, and transferable skills",
+      "  - For WMS students in their Praktikumsjahr: mention this is part of their commercial education program",
+      "  - Explain what the candidate hopes to learn during the internship/apprenticeship",
+      "  - Show awareness that this is a learning opportunity, not a senior position",
+      "  - If this is a spontaneous application (Initiativbewerbung): explain why the candidate is interested in this specific company",
+      "  - Keep the letter appropriately modest while still showcasing genuine strengths"
     ],
     "output_format": "ATS-optimized motivational letter with natural keyword integration and proper business letter format",
     "length_guideline": "3/4 to 1 page (concise but comprehensive)",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,11 @@ class User(Base):
     google_id = Column(String, unique=True, nullable=True, index=True)  # Google user ID
     profile_picture = Column(String, nullable=True)  # Profile picture URL
 
+    # Extended profile fields
+    employment_status = Column(String, nullable=True)  # "employed", "unemployed", "student", "transitioning"
+    education_type = Column(String, nullable=True)  # "wms", "bms", "university", "apprenticeship", "other", None
+    additional_profile_context = Column(Text, nullable=True)  # Free text for additional info
+
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     documents = relationship("Document", back_populates="owner")
@@ -74,6 +79,8 @@ class Application(Base):
     job_offer_url = Column(String, nullable=True)
     is_spontaneous = Column(Boolean, default=False)
     opportunity_context = Column(Text, nullable=True)
+    # Application type: "fulltime", "internship", "apprenticeship" (Praktikum/Lehrstelle)
+    application_type = Column(String, default="fulltime", nullable=False)
     applied = Column(Boolean, default=False)
     applied_at = Column(DateTime, nullable=True)
     result = Column(String, nullable=True)

--- a/backend/migrations/versions/20251204_01_add_profile_and_application_type_fields.py
+++ b/backend/migrations/versions/20251204_01_add_profile_and_application_type_fields.py
@@ -1,0 +1,70 @@
+"""Add extended profile fields and application_type.
+
+Adds to users table:
+- employment_status: Current employment status (employed, unemployed, student, transitioning)
+- education_type: Type of education (wms, bms, university, apprenticeship, other)
+- additional_profile_context: Free text for additional profile information
+
+Adds to applications table:
+- application_type: Type of application (fulltime, internship, apprenticeship)
+
+Revision ID: 20251204_01
+Revises: 20251203_01
+Create Date: 2025-12-04
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20251204_01"
+down_revision = "20251203_01"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(inspector, table_name: str, column_name: str) -> bool:
+    columns = [col['name'] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Add extended profile fields to users table
+    if _table_exists(inspector, "users"):
+        if not _column_exists(inspector, "users", "employment_status"):
+            op.add_column("users", sa.Column("employment_status", sa.String(), nullable=True))
+        if not _column_exists(inspector, "users", "education_type"):
+            op.add_column("users", sa.Column("education_type", sa.String(), nullable=True))
+        if not _column_exists(inspector, "users", "additional_profile_context"):
+            op.add_column("users", sa.Column("additional_profile_context", sa.Text(), nullable=True))
+
+    # Add application_type to applications table
+    if _table_exists(inspector, "applications"):
+        if not _column_exists(inspector, "applications", "application_type"):
+            op.add_column("applications", sa.Column("application_type", sa.String(), nullable=False, server_default="fulltime"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Remove extended profile fields from users table
+    if _table_exists(inspector, "users"):
+        if _column_exists(inspector, "users", "employment_status"):
+            op.drop_column("users", "employment_status")
+        if _column_exists(inspector, "users", "education_type"):
+            op.drop_column("users", "education_type")
+        if _column_exists(inspector, "users", "additional_profile_context"):
+            op.drop_column("users", "additional_profile_context")
+
+    # Remove application_type from applications table
+    if _table_exists(inspector, "applications"):
+        if _column_exists(inspector, "applications", "application_type"):
+            op.drop_column("applications", "application_type")

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ type ApplicationRecord = {
   job_offer_id?: number | null;
   is_spontaneous?: boolean;
   opportunity_context?: string | null;
+  application_type?: string; // fulltime, internship, apprenticeship
   job_description?: string | null;
   applied: boolean;
   applied_at?: string | null;
@@ -102,6 +103,7 @@ export default function DashboardPage() {
   const [targetCompany, setTargetCompany] = useState("");
   const [targetRole, setTargetRole] = useState("");
   const [opportunityContext, setOpportunityContext] = useState("");
+  const [applicationType, setApplicationType] = useState("fulltime"); // fulltime, internship, apprenticeship
   const [creatingSpontaneous, setCreatingSpontaneous] = useState(false);
   const [spontaneousError, setSpontaneousError] = useState("");
 
@@ -315,6 +317,7 @@ export default function DashboardPage() {
         job_title: result.title || t("dashboard.unknownPosition"),
         company: result.company || t("dashboard.unknownCompany"),
         job_offer_url: jobUrl,
+        application_type: applicationType,
         ui_language: resolveLanguageCode(user.mother_tongue || user.preferred_language, options),
         documentation_language: documentationLanguage,
         company_profile_language: companyProfileLanguage,
@@ -354,6 +357,7 @@ export default function DashboardPage() {
         job_title: targetRole,
         company: targetCompany,
         opportunity_context: opportunityContext || undefined,
+        application_type: applicationType,
         ui_language: resolveLanguageCode(user.mother_tongue || user.preferred_language, options),
         documentation_language: documentationLanguage,
         company_profile_language: companyProfileLanguage,
@@ -362,6 +366,7 @@ export default function DashboardPage() {
       setTargetCompany("");
       setTargetRole("");
       setOpportunityContext("");
+      setApplicationType("fulltime");
       await loadData();
       await refreshUser();
     } catch (error: any) {
@@ -717,7 +722,27 @@ export default function DashboardPage() {
                   />
                 </div>
 
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <label className="text-sm input-label">
+                    <span className="block mb-2">{t("dashboard.applicationType") || "Application Type"}</span>
+                    <select
+                      value={applicationType}
+                      onChange={(e) => setApplicationType(e.target.value)}
+                      className="input-base"
+                    >
+                      <option value="fulltime">{t("dashboard.fulltime") || "Full-time Position"}</option>
+                      <option value="internship">{t("dashboard.internship") || "Internship (Praktikum)"}</option>
+                      <option value="apprenticeship">{t("dashboard.apprenticeship") || "Apprenticeship (Lehrstelle)"}</option>
+                    </select>
+                    <span className="text-xs text-muted block mt-1">
+                      {applicationType === "internship"
+                        ? (t("dashboard.internshipHint") || "For practical training positions")
+                        : applicationType === "apprenticeship"
+                        ? (t("dashboard.apprenticeshipHint") || "For vocational training positions")
+                        : ""}
+                    </span>
+                  </label>
+
                   <label className="text-sm input-label">
                     <span className="block mb-2">Language for generated documents</span>
                     <select
@@ -774,7 +799,20 @@ export default function DashboardPage() {
                   required
                 />
 
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                  <label className="text-sm input-label">
+                    <span className="block mb-2">{t("dashboard.applicationType") || "Application Type"}</span>
+                    <select
+                      value={applicationType}
+                      onChange={(e) => setApplicationType(e.target.value)}
+                      className="input-base"
+                    >
+                      <option value="fulltime">{t("dashboard.fulltime") || "Full-time Position"}</option>
+                      <option value="internship">{t("dashboard.internship") || "Internship (Praktikum)"}</option>
+                      <option value="apprenticeship">{t("dashboard.apprenticeship") || "Apprenticeship (Lehrstelle)"}</option>
+                    </select>
+                  </label>
+
                   <label className="text-sm input-label">
                     <span className="block mb-2">Language for generated documents</span>
                     <select
@@ -936,11 +974,23 @@ export default function DashboardPage() {
                       {/* Collapsible Job Details */}
                       {expandedJobs.includes(app.id) ? (
                         <div className="space-y-3 pl-7">
-                          {app.is_spontaneous && (
-                            <span className="inline-block px-2 py-1 text-xs rounded bg-amber-900/50 text-amber-200 border border-amber-700">
-                              Spontaneous outreach
-                            </span>
-                          )}
+                          <div className="flex gap-2 flex-wrap">
+                            {app.is_spontaneous && (
+                              <span className="inline-block px-2 py-1 text-xs rounded bg-amber-900/50 text-amber-200 border border-amber-700">
+                                Spontaneous outreach
+                              </span>
+                            )}
+                            {app.application_type === "internship" && (
+                              <span className="inline-block px-2 py-1 text-xs rounded bg-purple-900/50 text-purple-200 border border-purple-700">
+                                Internship (Praktikum)
+                              </span>
+                            )}
+                            {app.application_type === "apprenticeship" && (
+                              <span className="inline-block px-2 py-1 text-xs rounded bg-blue-900/50 text-blue-200 border border-blue-700">
+                                Apprenticeship (Lehrstelle)
+                              </span>
+                            )}
+                          </div>
                           {app.job_offer_url && (
                             <a
                               href={app.job_offer_url}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -26,6 +26,10 @@ export default function SettingsPage() {
   const [preferredLanguage, setPreferredLanguage] = useState("");
   const [motherTongue, setMotherTongue] = useState("");
   const [documentationLanguage, setDocumentationLanguage] = useState("");
+  // Extended profile fields
+  const [employmentStatus, setEmploymentStatus] = useState("");
+  const [educationType, setEducationType] = useState("");
+  const [additionalProfileContext, setAdditionalProfileContext] = useState("");
   const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>(FALLBACK_LANGUAGE_OPTIONS);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
@@ -43,6 +47,10 @@ export default function SettingsPage() {
       setPreferredLanguage(user.preferred_language || "en");
       setMotherTongue(user.mother_tongue || "en");
       setDocumentationLanguage(user.documentation_language || "en");
+      // Extended profile fields
+      setEmploymentStatus(user.employment_status || "");
+      setEducationType(user.education_type || "");
+      setAdditionalProfileContext(user.additional_profile_context || "");
 
       api
         .listLanguages()
@@ -64,7 +72,10 @@ export default function SettingsPage() {
         fullName,
         preferredLanguage,
         motherTongue,
-        documentationLanguage
+        documentationLanguage,
+        employmentStatus || undefined,
+        educationType || undefined,
+        additionalProfileContext || undefined
       );
       await refreshUser();
       setSuccess(t("settings.settingsSaved"));
@@ -206,6 +217,72 @@ export default function SettingsPage() {
                   </select>
                   <p className="text-xs text-slate-500 mt-1">
                     {t("settings.documentationLanguageHint")}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Extended Profile Settings */}
+            <div className="space-y-4 pt-4 border-t border-slate-700">
+              <h2 className="text-xl font-semibold">{t("settings.extendedProfile") || "Extended Profile"}</h2>
+              <p className="text-sm text-slate-400">
+                {t("settings.extendedProfileDescription") || "Additional information to help generate more personalized application documents."}
+              </p>
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-slate-200 mb-2">
+                    {t("settings.employmentStatus") || "Employment Status"}
+                  </label>
+                  <select
+                    value={employmentStatus}
+                    onChange={(e) => setEmploymentStatus(e.target.value)}
+                    className="w-full px-4 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    <option value="">{t("settings.selectOption") || "-- Select --"}</option>
+                    <option value="employed">{t("settings.employed") || "Currently employed"}</option>
+                    <option value="unemployed">{t("settings.unemployed") || "Currently unemployed"}</option>
+                    <option value="student">{t("settings.student") || "Student"}</option>
+                    <option value="transitioning">{t("settings.transitioning") || "In career transition"}</option>
+                  </select>
+                  <p className="text-xs text-slate-500 mt-1">
+                    {t("settings.employmentStatusHint") || "Your current employment situation helps tailor the tone of your applications."}
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-200 mb-2">
+                    {t("settings.educationType") || "Education Type"}
+                  </label>
+                  <select
+                    value={educationType}
+                    onChange={(e) => setEducationType(e.target.value)}
+                    className="w-full px-4 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    <option value="">{t("settings.selectOption") || "-- Select --"}</option>
+                    <option value="wms">{t("settings.wms") || "WMS (Wirtschaftsmittelschule)"}</option>
+                    <option value="bms">{t("settings.bms") || "BMS (Berufsmaturitätsschule)"}</option>
+                    <option value="university">{t("settings.university") || "University / FH"}</option>
+                    <option value="apprenticeship">{t("settings.apprenticeship") || "Apprenticeship (Berufslehre)"}</option>
+                    <option value="other">{t("settings.other") || "Other"}</option>
+                  </select>
+                  <p className="text-xs text-slate-500 mt-1">
+                    {t("settings.educationTypeHint") || "Your education background helps personalize applications, especially for internship positions."}
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-200 mb-2">
+                    {t("settings.additionalContext") || "Additional Context"}
+                  </label>
+                  <textarea
+                    value={additionalProfileContext}
+                    onChange={(e) => setAdditionalProfileContext(e.target.value)}
+                    placeholder={t("settings.additionalContextPlaceholder") || "e.g., I am in my practical year (Praktikumsjahr) as part of my WMS education..."}
+                    className="w-full px-4 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 min-h-[100px]"
+                  />
+                  <p className="text-xs text-slate-500 mt-1">
+                    {t("settings.additionalContextHint") || "Any additional information relevant to your job applications."}
                   </p>
                 </div>
               </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -11,6 +11,10 @@ export interface User {
   preferred_language: string;
   mother_tongue: string;
   documentation_language: string;
+  // Extended profile fields
+  employment_status?: string | null; // "employed", "unemployed", "student", "transitioning"
+  education_type?: string | null; // "wms", "bms", "university", "apprenticeship", "other"
+  additional_profile_context?: string | null; // Free text for additional info
   credits: number;
   created_at: string;
   is_admin: boolean;
@@ -57,6 +61,7 @@ export interface Application {
   job_offer_url: string | null;
   is_spontaneous: boolean;
   opportunity_context: string | null;
+  application_type: string; // "fulltime", "internship", "apprenticeship"
   job_description: string | null;
   applied: boolean;
   applied_at: string | null;
@@ -252,6 +257,9 @@ class ApiClient {
     preferredLanguage?: string,
     motherTongue?: string,
     documentationLanguage?: string,
+    employmentStatus?: string,
+    educationType?: string,
+    additionalProfileContext?: string,
   ) {
     return this.request<User>("/users/me", {
       method: "PATCH",
@@ -260,6 +268,9 @@ class ApiClient {
         preferred_language: preferredLanguage,
         mother_tongue: motherTongue,
         documentation_language: documentationLanguage,
+        employment_status: employmentStatus,
+        education_type: educationType,
+        additional_profile_context: additionalProfileContext,
       }),
     });
   }
@@ -332,6 +343,7 @@ class ApiClient {
     job_offer_url?: string;
     is_spontaneous?: boolean;
     opportunity_context?: string;
+    application_type?: string; // "fulltime", "internship", "apprenticeship"
     applied?: boolean;
     applied_at?: string;
     result?: string;
@@ -349,6 +361,7 @@ class ApiClient {
     job_title: string;
     company: string;
     opportunity_context?: string;
+    application_type?: string; // "fulltime", "internship", "apprenticeship"
     ui_language?: string;
     documentation_language?: string;
     company_profile_language?: string;


### PR DESCRIPTION
This commit adds:
- Application type field (fulltime, internship, apprenticeship) to allow users to specify if they're applying for a Praktikum or Lehrstelle
- Extended profile fields on the User model:
  - employment_status: employed, unemployed, student, transitioning
  - education_type: wms, bms, university, apprenticeship, other
  - additional_profile_context: free text for additional info
- Updated prompts to handle internship/apprenticeship applications with appropriate tone and focus on learning opportunities
- Settings page now includes extended profile section
- Dashboard allows selecting application type when creating applications
- Migration file for the new database columns

These changes enable WMS students in their Praktikumsjahr and other users seeking internships or apprenticeships to generate more appropriately tailored application documents.