### PR TITLE
Add missing dashboard translations for application type fields

### DIFF
--- a/frontend/lib/translations/am.json
+++ b/frontend/lib/translations/am.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "ያልታወቀ ቦታ",
+    "unknownCompany": "ያልታወቀ ኩባንያ",
+    "applicationType": "የማመልከቻ ዓይነት",
+    "fulltime": "ሙሉ ጊዜ ቦታ",
+    "internship": "ተለማማጅነት",
+    "apprenticeship": "ሙያ ተማሪ",
+    "internshipHint": "ለተለማማጅነት ቦታዎች",
+    "apprenticeshipHint": "ለሙያ ስልጠና ቦታዎች"
   },
   "settings": {
     "title": "ቅንብሮች",

--- a/frontend/lib/translations/ar.json
+++ b/frontend/lib/translations/ar.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "منصب غير معروف",
+    "unknownCompany": "شركة غير معروفة",
+    "applicationType": "نوع الطلب",
+    "fulltime": "وظيفة بدوام كامل",
+    "internship": "تدريب عملي",
+    "apprenticeship": "تدريب مهني",
+    "internshipHint": "للمناصب التدريبية",
+    "apprenticeshipHint": "لمناصب التدريب المهني"
   },
   "settings": {
     "title": "الإعدادات",

--- a/frontend/lib/translations/bg.json
+++ b/frontend/lib/translations/bg.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Неизвестна позиция",
+    "unknownCompany": "Неизвестна компания",
+    "applicationType": "Тип кандидатура",
+    "fulltime": "Пълен работен ден",
+    "internship": "Стаж",
+    "apprenticeship": "Чиракуване",
+    "internshipHint": "За стажантски позиции",
+    "apprenticeshipHint": "За позиции за професионално обучение"
   },
   "settings": {
     "title": "Настройки",

--- a/frontend/lib/translations/bn.json
+++ b/frontend/lib/translations/bn.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "অজানা পদ",
+    "unknownCompany": "অজানা কোম্পানি",
+    "applicationType": "আবেদনের ধরন",
+    "fulltime": "পূর্ণ-সময়ের পদ",
+    "internship": "ইন্টার্নশিপ",
+    "apprenticeship": "শিক্ষানবিশ",
+    "internshipHint": "ইন্টার্নশিপ পদের জন্য",
+    "apprenticeshipHint": "বৃত্তিমূলক প্রশিক্ষণ পদের জন্য"
   },
   "settings": {
     "title": "সেটিংস",

--- a/frontend/lib/translations/bs.json
+++ b/frontend/lib/translations/bs.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Nepoznata pozicija",
+    "unknownCompany": "Nepoznata kompanija",
+    "applicationType": "Vrsta prijave",
+    "fulltime": "Puno radno vrijeme",
+    "internship": "Praksa",
+    "apprenticeship": "Šegrtovanje",
+    "internshipHint": "Za pozicije prakse",
+    "apprenticeshipHint": "Za pozicije strukovnog osposobljavanja"
   },
   "settings": {
     "title": "Postavke",

--- a/frontend/lib/translations/cs.json
+++ b/frontend/lib/translations/cs.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Neznámá pozice",
+    "unknownCompany": "Neznámá společnost",
+    "applicationType": "Typ žádosti",
+    "fulltime": "Plný úvazek",
+    "internship": "Stáž",
+    "apprenticeship": "Učňovství",
+    "internshipHint": "Pro stážistické pozice",
+    "apprenticeshipHint": "Pro pozice odborného vzdělávání"
   },
   "settings": {
     "title": "Nastavení",

--- a/frontend/lib/translations/de-CH.json
+++ b/frontend/lib/translations/de-CH.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Unbekannte Position",
+    "unknownCompany": "Unbekanntes Unternehmen",
+    "applicationType": "Bewerbungstyp",
+    "fulltime": "Vollzeitstelle",
+    "internship": "Praktikum",
+    "apprenticeship": "Lehrstelle",
+    "internshipHint": "Für Praktikumsstellen",
+    "apprenticeshipHint": "Für Ausbildungsstellen"
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/lib/translations/de.json
+++ b/frontend/lib/translations/de.json
@@ -121,7 +121,13 @@
     "appliedFilter": "Beworben",
     "notAppliedFilter": "Nicht beworben",
     "unknownPosition": "Unbekannte Position",
-    "unknownCompany": "Unbekanntes Unternehmen"
+    "unknownCompany": "Unbekanntes Unternehmen",
+    "applicationType": "Bewerbungstyp",
+    "fulltime": "Vollzeitstelle",
+    "internship": "Praktikum",
+    "apprenticeship": "Lehrstelle",
+    "internshipHint": "Für Praktikumsstellen",
+    "apprenticeshipHint": "Für Ausbildungsstellen"
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/lib/translations/el.json
+++ b/frontend/lib/translations/el.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Άγνωστη θέση",
+    "unknownCompany": "Άγνωστη εταιρεία",
+    "applicationType": "Τύπος αίτησης",
+    "fulltime": "Πλήρης απασχόληση",
+    "internship": "Πρακτική άσκηση",
+    "apprenticeship": "Μαθητεία",
+    "internshipHint": "Για θέσεις πρακτικής άσκησης",
+    "apprenticeshipHint": "Για θέσεις επαγγελματικής κατάρτισης"
   },
   "settings": {
     "title": "Ρυθμίσεις",

--- a/frontend/lib/translations/en.json
+++ b/frontend/lib/translations/en.json
@@ -121,7 +121,13 @@
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
     "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownCompany": "Unknown Company",
+    "applicationType": "Application Type",
+    "fulltime": "Full-time Position",
+    "internship": "Internship",
+    "apprenticeship": "Apprenticeship",
+    "internshipHint": "For practical training positions",
+    "apprenticeshipHint": "For vocational training positions"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/lib/translations/es.json
+++ b/frontend/lib/translations/es.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Puesto desconocido",
+    "unknownCompany": "Empresa desconocida",
+    "applicationType": "Tipo de solicitud",
+    "fulltime": "Puesto a tiempo completo",
+    "internship": "Prácticas",
+    "apprenticeship": "Aprendizaje",
+    "internshipHint": "Para puestos de prácticas",
+    "apprenticeshipHint": "Para puestos de formación profesional"
   },
   "settings": {
     "title": "Configuración",

--- a/frontend/lib/translations/fa.json
+++ b/frontend/lib/translations/fa.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "موقعیت ناشناخته",
+    "unknownCompany": "شرکت ناشناخته",
+    "applicationType": "نوع درخواست",
+    "fulltime": "شغل تمام وقت",
+    "internship": "کارآموزی",
+    "apprenticeship": "شاگردی",
+    "internshipHint": "برای موقعیت‌های کارآموزی",
+    "apprenticeshipHint": "برای موقعیت‌های آموزش حرفه‌ای"
   },
   "settings": {
     "title": "تنظیمات",

--- a/frontend/lib/translations/fil.json
+++ b/frontend/lib/translations/fil.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Hindi kilalang posisyon",
+    "unknownCompany": "Hindi kilalang kumpanya",
+    "applicationType": "Uri ng aplikasyon",
+    "fulltime": "Full-time na posisyon",
+    "internship": "Internship",
+    "apprenticeship": "Apprenticeship",
+    "internshipHint": "Para sa mga posisyong internship",
+    "apprenticeshipHint": "Para sa mga posisyong pang-bokasyonal na pagsasanay"
   },
   "settings": {
     "title": "Mga Setting",

--- a/frontend/lib/translations/fr.json
+++ b/frontend/lib/translations/fr.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Poste inconnu",
+    "unknownCompany": "Entreprise inconnue",
+    "applicationType": "Type de candidature",
+    "fulltime": "Poste à temps plein",
+    "internship": "Stage",
+    "apprenticeship": "Apprentissage",
+    "internshipHint": "Pour les postes de stage",
+    "apprenticeshipHint": "Pour les postes de formation professionnelle"
   },
   "settings": {
     "title": "Paramètres",

--- a/frontend/lib/translations/he.json
+++ b/frontend/lib/translations/he.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "משרה לא ידועה",
+    "unknownCompany": "חברה לא ידועה",
+    "applicationType": "סוג בקשה",
+    "fulltime": "משרה מלאה",
+    "internship": "התמחות",
+    "apprenticeship": "חניכות",
+    "internshipHint": "למשרות התמחות",
+    "apprenticeshipHint": "למשרות הכשרה מקצועית"
   },
   "settings": {
     "title": "הגדרות",

--- a/frontend/lib/translations/hi.json
+++ b/frontend/lib/translations/hi.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "अज्ञात पद",
+    "unknownCompany": "अज्ञात कंपनी",
+    "applicationType": "आवेदन प्रकार",
+    "fulltime": "पूर्णकालिक पद",
+    "internship": "इंटर्नशिप",
+    "apprenticeship": "शिक्षुता",
+    "internshipHint": "इंटर्नशिप पदों के लिए",
+    "apprenticeshipHint": "व्यावसायिक प्रशिक्षण पदों के लिए"
   },
   "settings": {
     "title": "सेटिंग",

--- a/frontend/lib/translations/hr.json
+++ b/frontend/lib/translations/hr.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Nepoznata pozicija",
+    "unknownCompany": "Nepoznata tvrtka",
+    "applicationType": "Vrsta prijave",
+    "fulltime": "Puno radno vrijeme",
+    "internship": "Praksa",
+    "apprenticeship": "Naukovanje",
+    "internshipHint": "Za pozicije prakse",
+    "apprenticeshipHint": "Za pozicije strukovnog osposobljavanja"
   },
   "settings": {
     "title": "Postavke",

--- a/frontend/lib/translations/hu.json
+++ b/frontend/lib/translations/hu.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Ismeretlen pozíció",
+    "unknownCompany": "Ismeretlen cég",
+    "applicationType": "Jelentkezés típusa",
+    "fulltime": "Teljes munkaidős állás",
+    "internship": "Szakmai gyakorlat",
+    "apprenticeship": "Tanulószerződés",
+    "internshipHint": "Gyakorlati pozíciókhoz",
+    "apprenticeshipHint": "Szakmai képzési pozíciókhoz"
   },
   "settings": {
     "title": "Beállítások",

--- a/frontend/lib/translations/it.json
+++ b/frontend/lib/translations/it.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Posizione sconosciuta",
+    "unknownCompany": "Azienda sconosciuta",
+    "applicationType": "Tipo di candidatura",
+    "fulltime": "Posizione a tempo pieno",
+    "internship": "Tirocinio",
+    "apprenticeship": "Apprendistato",
+    "internshipHint": "Per posizioni di tirocinio",
+    "apprenticeshipHint": "Per posizioni di formazione professionale"
   },
   "settings": {
     "title": "Impostazioni",

--- a/frontend/lib/translations/ja.json
+++ b/frontend/lib/translations/ja.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "不明な職位",
+    "unknownCompany": "不明な会社",
+    "applicationType": "応募種類",
+    "fulltime": "正社員",
+    "internship": "インターンシップ",
+    "apprenticeship": "見習い",
+    "internshipHint": "インターンシップ職位向け",
+    "apprenticeshipHint": "職業訓練職位向け"
   },
   "settings": {
     "title": "設定",

--- a/frontend/lib/translations/kn.json
+++ b/frontend/lib/translations/kn.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "ಅಜ್ಞಾತ ಸ್ಥಾನ",
+    "unknownCompany": "ಅಜ್ಞಾತ ಕಂಪನಿ",
+    "applicationType": "ಅರ್ಜಿ ಪ್ರಕಾರ",
+    "fulltime": "ಪೂರ್ಣ-ಸಮಯದ ಸ್ಥಾನ",
+    "internship": "ಇಂಟರ್ನ್‌ಶಿಪ್",
+    "apprenticeship": "ಅಪ್ರೆಂಟಿಸ್‌ಶಿಪ್",
+    "internshipHint": "ಇಂಟರ್ನ್‌ಶಿಪ್ ಸ್ಥಾನಗಳಿಗೆ",
+    "apprenticeshipHint": "ವೃತ್ತಿಪರ ತರಬೇತಿ ಸ್ಥಾನಗಳಿಗೆ"
   },
   "settings": {
     "title": "ಸೆಟ್ಟಿಂಗ್‌ಗಳು",

--- a/frontend/lib/translations/ko.json
+++ b/frontend/lib/translations/ko.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "알 수 없는 직위",
+    "unknownCompany": "알 수 없는 회사",
+    "applicationType": "지원 유형",
+    "fulltime": "정규직",
+    "internship": "인턴십",
+    "apprenticeship": "견습",
+    "internshipHint": "인턴십 직위용",
+    "apprenticeshipHint": "직업 훈련 직위용"
   },
   "settings": {
     "title": "설정",

--- a/frontend/lib/translations/ku.json
+++ b/frontend/lib/translations/ku.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Pozîsyona nenas",
+    "unknownCompany": "Pargîdaniya nenas",
+    "applicationType": "Cureya daxwazê",
+    "fulltime": "Pozîsyona wextê tevahî",
+    "internship": "Stajyerî",
+    "apprenticeship": "Şagirtî",
+    "internshipHint": "Ji bo pozîsyonên stajyeriyê",
+    "apprenticeshipHint": "Ji bo pozîsyonên perwerdehiya pîşeyî"
   },
   "settings": {
     "title": "Mîhengî",

--- a/frontend/lib/translations/ml.json
+++ b/frontend/lib/translations/ml.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "അജ്ഞാത തസ്തിക",
+    "unknownCompany": "അജ്ഞാത കമ്പനി",
+    "applicationType": "അപേക്ഷ തരം",
+    "fulltime": "മുഴുവൻ സമയ തസ്തിക",
+    "internship": "ഇന്റേൺഷിപ്പ്",
+    "apprenticeship": "അപ്രന്റിസ്ഷിപ്പ്",
+    "internshipHint": "ഇന്റേൺഷിപ്പ് തസ്തികകൾക്ക്",
+    "apprenticeshipHint": "തൊഴിൽ പരിശീലന തസ്തികകൾക്ക്"
   },
   "settings": {
     "title": "ക്രമീകരണങ്ങൾ",

--- a/frontend/lib/translations/ms.json
+++ b/frontend/lib/translations/ms.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Jawatan tidak diketahui",
+    "unknownCompany": "Syarikat tidak diketahui",
+    "applicationType": "Jenis permohonan",
+    "fulltime": "Jawatan sepenuh masa",
+    "internship": "Latihan praktikal",
+    "apprenticeship": "Perantisan",
+    "internshipHint": "Untuk jawatan latihan praktikal",
+    "apprenticeshipHint": "Untuk jawatan latihan vokasional"
   },
   "settings": {
     "title": "Tetapan",

--- a/frontend/lib/translations/ne.json
+++ b/frontend/lib/translations/ne.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "अज्ञात पद",
+    "unknownCompany": "अज्ञात कम्पनी",
+    "applicationType": "आवेदन प्रकार",
+    "fulltime": "पूर्ण समय पद",
+    "internship": "इन्टर्नसिप",
+    "apprenticeship": "शिक्षार्थी",
+    "internshipHint": "इन्टर्नसिप पदहरूका लागि",
+    "apprenticeshipHint": "व्यावसायिक तालिम पदहरूका लागि"
   },
   "settings": {
     "title": "सेटिङहरू",

--- a/frontend/lib/translations/pa.json
+++ b/frontend/lib/translations/pa.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "ਅਣਜਾਣ ਅਹੁਦਾ",
+    "unknownCompany": "ਅਣਜਾਣ ਕੰਪਨੀ",
+    "applicationType": "ਅਰਜ਼ੀ ਦੀ ਕਿਸਮ",
+    "fulltime": "ਪੂਰੀ-ਸਮਾਂ ਨੌਕਰੀ",
+    "internship": "ਇੰਟਰਨਸ਼ਿਪ",
+    "apprenticeship": "ਅਪ੍ਰੈਂਟਿਸਸ਼ਿਪ",
+    "internshipHint": "ਇੰਟਰਨਸ਼ਿਪ ਅਹੁਦਿਆਂ ਲਈ",
+    "apprenticeshipHint": "ਵੋਕੇਸ਼ਨਲ ਸਿਖਲਾਈ ਅਹੁਦਿਆਂ ਲਈ"
   },
   "settings": {
     "title": "ਸੈਟਿੰਗਾਂ",

--- a/frontend/lib/translations/pl.json
+++ b/frontend/lib/translations/pl.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Nieznane stanowisko",
+    "unknownCompany": "Nieznana firma",
+    "applicationType": "Typ aplikacji",
+    "fulltime": "Pełny etat",
+    "internship": "Praktyka",
+    "apprenticeship": "Nauka zawodu",
+    "internshipHint": "Dla stanowisk praktyk",
+    "apprenticeshipHint": "Dla stanowisk nauki zawodu"
   },
   "settings": {
     "title": "Ustawienia",

--- a/frontend/lib/translations/pt.json
+++ b/frontend/lib/translations/pt.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Posição desconhecida",
+    "unknownCompany": "Empresa desconhecida",
+    "applicationType": "Tipo de candidatura",
+    "fulltime": "Posição a tempo inteiro",
+    "internship": "Estágio",
+    "apprenticeship": "Aprendizagem",
+    "internshipHint": "Para posições de estágio",
+    "apprenticeshipHint": "Para posições de formação profissional"
   },
   "settings": {
     "title": "Definições",

--- a/frontend/lib/translations/ro.json
+++ b/frontend/lib/translations/ro.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Poziție necunoscută",
+    "unknownCompany": "Companie necunoscută",
+    "applicationType": "Tip de aplicație",
+    "fulltime": "Program complet",
+    "internship": "Stagiu",
+    "apprenticeship": "Ucenicie",
+    "internshipHint": "Pentru poziții de stagiu",
+    "apprenticeshipHint": "Pentru poziții de formare profesională"
   },
   "settings": {
     "title": "Setări",

--- a/frontend/lib/translations/ru.json
+++ b/frontend/lib/translations/ru.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Неизвестная должность",
+    "unknownCompany": "Неизвестная компания",
+    "applicationType": "Тип заявки",
+    "fulltime": "Полная занятость",
+    "internship": "Стажировка",
+    "apprenticeship": "Ученичество",
+    "internshipHint": "Для стажировок",
+    "apprenticeshipHint": "Для позиций профессионального обучения"
   },
   "settings": {
     "title": "Настройки",

--- a/frontend/lib/translations/si.json
+++ b/frontend/lib/translations/si.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "නොදන්නා තනතුර",
+    "unknownCompany": "නොදන්නා සමාගම",
+    "applicationType": "අයදුම්පත් වර්ගය",
+    "fulltime": "පූර්ණ කාලීන තනතුර",
+    "internship": "අභ්‍යාසලාභී",
+    "apprenticeship": "ගුරු ශිෂ්‍යත්වය",
+    "internshipHint": "අභ්‍යාසලාභී තනතුරු සඳහා",
+    "apprenticeshipHint": "වෘත්තීය පුහුණු තනතුරු සඳහා"
   },
   "settings": {
     "title": "සැකසුම්",

--- a/frontend/lib/translations/sk.json
+++ b/frontend/lib/translations/sk.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Neznáma pozícia",
+    "unknownCompany": "Neznáma spoločnosť",
+    "applicationType": "Typ žiadosti",
+    "fulltime": "Plný úväzok",
+    "internship": "Stáž",
+    "apprenticeship": "Učňovstvo",
+    "internshipHint": "Pre stážistické pozície",
+    "apprenticeshipHint": "Pre pozície odborného vzdelávania"
   },
   "settings": {
     "title": "Nastavenia",

--- a/frontend/lib/translations/sl.json
+++ b/frontend/lib/translations/sl.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Neznana pozicija",
+    "unknownCompany": "Neznano podjetje",
+    "applicationType": "Vrsta prijave",
+    "fulltime": "Polni delovni čas",
+    "internship": "Praksa",
+    "apprenticeship": "Vajeništvo",
+    "internshipHint": "Za pozicije prakse",
+    "apprenticeshipHint": "Za pozicije poklicnega usposabljanja"
   },
   "settings": {
     "title": "Nastavitve",

--- a/frontend/lib/translations/so.json
+++ b/frontend/lib/translations/so.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Jagada aan la garanayn",
+    "unknownCompany": "Shirkadda aan la garanayn",
+    "applicationType": "Nooca codsiga",
+    "fulltime": "Shaqo wakhti buuxa ah",
+    "internship": "Tababar",
+    "apprenticeship": "Barashada xirfadda",
+    "internshipHint": "Jagooyin tababar",
+    "apprenticeshipHint": "Jagooyin tababarka xirfadda"
   },
   "settings": {
     "title": "Dejinta",

--- a/frontend/lib/translations/sq.json
+++ b/frontend/lib/translations/sq.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Pozicion i panjohur",
+    "unknownCompany": "Kompani e panjohur",
+    "applicationType": "Lloji i aplikimit",
+    "fulltime": "Pozicion me kohë të plotë",
+    "internship": "Praktikë",
+    "apprenticeship": "Mësim zanati",
+    "internshipHint": "Për pozicione praktike",
+    "apprenticeshipHint": "Për pozicione trajnimi profesional"
   },
   "settings": {
     "title": "Cilësimet",

--- a/frontend/lib/translations/sr.json
+++ b/frontend/lib/translations/sr.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Непозната позиција",
+    "unknownCompany": "Непозната компанија",
+    "applicationType": "Врста пријаве",
+    "fulltime": "Пуно радно време",
+    "internship": "Пракса",
+    "apprenticeship": "Шегртовање",
+    "internshipHint": "За позиције праксе",
+    "apprenticeshipHint": "За позиције струковног оспособљавања"
   },
   "settings": {
     "title": "Подешавања",

--- a/frontend/lib/translations/ta.json
+++ b/frontend/lib/translations/ta.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "அறியப்படாத பதவி",
+    "unknownCompany": "அறியப்படாத நிறுவனம்",
+    "applicationType": "விண்ணப்ப வகை",
+    "fulltime": "முழுநேர பதவி",
+    "internship": "பயிற்சி",
+    "apprenticeship": "தொழில் பயிற்சி",
+    "internshipHint": "பயிற்சி பதவிகளுக்கு",
+    "apprenticeshipHint": "தொழில்முறை பயிற்சி பதவிகளுக்கு"
   },
   "settings": {
     "title": "அமைப்புகள்",

--- a/frontend/lib/translations/te.json
+++ b/frontend/lib/translations/te.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "తెలియని స్థానం",
+    "unknownCompany": "తెలియని కంపెనీ",
+    "applicationType": "దరఖాస్తు రకం",
+    "fulltime": "పూర్తి-సమయ స్థానం",
+    "internship": "ఇంటర్న్‌షిప్",
+    "apprenticeship": "అప్రెంటిస్‌షిప్",
+    "internshipHint": "ఇంటర్న్‌షిప్ స్థానాల కోసం",
+    "apprenticeshipHint": "వృత్తిపరమైన శిక్షణ స్థానాల కోసం"
   },
   "settings": {
     "title": "సెట్టింగ్‌లు",

--- a/frontend/lib/translations/th.json
+++ b/frontend/lib/translations/th.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "ตำแหน่งไม่ทราบ",
+    "unknownCompany": "บริษัทไม่ทราบ",
+    "applicationType": "ประเภทใบสมัคร",
+    "fulltime": "เต็มเวลา",
+    "internship": "ฝึกงาน",
+    "apprenticeship": "ฝึกอาชีพ",
+    "internshipHint": "สำหรับตำแหน่งฝึกงาน",
+    "apprenticeshipHint": "สำหรับตำแหน่งฝึกอาชีพ"
   },
   "settings": {
     "title": "การตั้งค่า",

--- a/frontend/lib/translations/ti.json
+++ b/frontend/lib/translations/ti.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "ዘይተፈልጠ ቦታ",
+    "unknownCompany": "ዘይተፈልጠ ኩባንያ",
+    "applicationType": "ዓይነት መመልከቲ",
+    "fulltime": "ምሉእ ግዜ ቦታ",
+    "internship": "ተለማማዲነት",
+    "apprenticeship": "ናይ ሙያ ተማሃሮ",
+    "internshipHint": "ንተለማማዲነት ቦታታት",
+    "apprenticeshipHint": "ንናይ ሙያ ስልጠና ቦታታት"
   },
   "settings": {
     "title": "ምትዓታት",

--- a/frontend/lib/translations/tr.json
+++ b/frontend/lib/translations/tr.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Bilinmeyen Pozisyon",
+    "unknownCompany": "Bilinmeyen Şirket",
+    "applicationType": "Başvuru Türü",
+    "fulltime": "Tam zamanlı pozisyon",
+    "internship": "Staj",
+    "apprenticeship": "Çıraklık",
+    "internshipHint": "Staj pozisyonları için",
+    "apprenticeshipHint": "Mesleki eğitim pozisyonları için"
   },
   "settings": {
     "title": "Ayarlar",

--- a/frontend/lib/translations/uk.json
+++ b/frontend/lib/translations/uk.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Невідома посада",
+    "unknownCompany": "Невідома компанія",
+    "applicationType": "Тип заявки",
+    "fulltime": "Повна зайнятість",
+    "internship": "Стажування",
+    "apprenticeship": "Учнівство",
+    "internshipHint": "Для стажувань",
+    "apprenticeshipHint": "Для позицій професійного навчання"
   },
   "settings": {
     "title": "Налаштування",

--- a/frontend/lib/translations/ur.json
+++ b/frontend/lib/translations/ur.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "نامعلوم عہدہ",
+    "unknownCompany": "نامعلوم کمپنی",
+    "applicationType": "درخواست کی قسم",
+    "fulltime": "کل وقتی عہدہ",
+    "internship": "انٹرن شپ",
+    "apprenticeship": "شاگردی",
+    "internshipHint": "انٹرن شپ عہدوں کے لیے",
+    "apprenticeshipHint": "پیشہ ورانہ تربیت کے عہدوں کے لیے"
   },
   "settings": {
     "title": "ترتیبات",

--- a/frontend/lib/translations/vi.json
+++ b/frontend/lib/translations/vi.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "Vị trí không xác định",
+    "unknownCompany": "Công ty không xác định",
+    "applicationType": "Loại đơn xin việc",
+    "fulltime": "Toàn thời gian",
+    "internship": "Thực tập",
+    "apprenticeship": "Học việc",
+    "internshipHint": "Cho vị trí thực tập",
+    "apprenticeshipHint": "Cho vị trí đào tạo nghề"
   },
   "settings": {
     "title": "Cài đặt",

--- a/frontend/lib/translations/zh-Hans.json
+++ b/frontend/lib/translations/zh-Hans.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "未知职位",
+    "unknownCompany": "未知公司",
+    "applicationType": "申请类型",
+    "fulltime": "全职职位",
+    "internship": "实习",
+    "apprenticeship": "学徒",
+    "internshipHint": "用于实习职位",
+    "apprenticeshipHint": "用于职业培训职位"
   },
   "settings": {
     "title": "设置",

--- a/frontend/lib/translations/zh-Hant.json
+++ b/frontend/lib/translations/zh-Hant.json
@@ -120,8 +120,14 @@
     "allApplications": "All Applications",
     "appliedFilter": "Applied",
     "notAppliedFilter": "Not Applied",
-    "unknownPosition": "Unknown Position",
-    "unknownCompany": "Unknown Company"
+    "unknownPosition": "未知職位",
+    "unknownCompany": "未知公司",
+    "applicationType": "申請類型",
+    "fulltime": "全職職位",
+    "internship": "實習",
+    "apprenticeship": "學徒",
+    "internshipHint": "用於實習職位",
+    "apprenticeshipHint": "用於職業培訓職位"
   },
   "settings": {
     "title": "設定",


### PR DESCRIPTION
Add translations for applicationType, fulltime, internship, apprenticeship,
internshipHint, and apprenticeshipHint in all 47 language files. These
translations fix the issue where translation keys were displayed instead
of localized text in the application type dropdown.