### PR TITLE
Create document template admin system

### DIFF
--- a/backend/app/api/endpoints/document_templates.py
+++ b/backend/app/api/endpoints/document_templates.py
@@ -1,0 +1,241 @@
+"""API endpoints for managing document templates (admin only)."""
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import DocumentTemplate, User
+from app.api.endpoints.admin import get_admin_user
+from app.limiter import limiter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# Pydantic Schemas
+class DocumentTemplateBase(BaseModel):
+    doc_type: str
+    display_name: str
+    credit_cost: int = Field(ge=0, le=10, default=1)
+    language_source: str = Field(
+        default="documentation_language",
+        pattern="^(preferred_language|mother_tongue|documentation_language)$"
+    )
+    llm_provider: str = Field(default="openai")
+    llm_model: str = Field(default="gpt-4")
+    prompt_template: str
+    is_active: bool = True
+
+
+class DocumentTemplateCreate(DocumentTemplateBase):
+    pass
+
+
+class DocumentTemplateUpdate(BaseModel):
+    display_name: Optional[str] = None
+    credit_cost: Optional[int] = Field(None, ge=0, le=10)
+    language_source: Optional[str] = Field(
+        None,
+        pattern="^(preferred_language|mother_tongue|documentation_language)$"
+    )
+    llm_provider: Optional[str] = None
+    llm_model: Optional[str] = None
+    prompt_template: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class DocumentTemplateResponse(BaseModel):
+    id: int
+    doc_type: str
+    display_name: str
+    credit_cost: int
+    language_source: str
+    llm_provider: str
+    llm_model: str
+    prompt_template: str
+    is_active: bool
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+def serialize_document_template(template: DocumentTemplate) -> dict:
+    """Serialize a DocumentTemplate to a dictionary."""
+    return {
+        "id": template.id,
+        "doc_type": template.doc_type,
+        "display_name": template.display_name,
+        "credit_cost": template.credit_cost,
+        "language_source": template.language_source,
+        "llm_provider": template.llm_provider,
+        "llm_model": template.llm_model,
+        "prompt_template": template.prompt_template,
+        "is_active": template.is_active,
+        "created_at": template.created_at.isoformat() if template.created_at else None,
+        "updated_at": template.updated_at.isoformat() if template.updated_at else None,
+    }
+
+
+@router.get("/", response_model=List[DocumentTemplateResponse])
+@limiter.limit("30/minute")
+async def list_document_templates(
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """List all document templates (admin only)."""
+    templates = db.query(DocumentTemplate).order_by(DocumentTemplate.doc_type).all()
+    return [serialize_document_template(t) for t in templates]
+
+
+@router.get("/{template_id}", response_model=DocumentTemplateResponse)
+@limiter.limit("30/minute")
+async def get_document_template(
+    template_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """Get a specific document template (admin only)."""
+    template = db.query(DocumentTemplate).filter(
+        DocumentTemplate.id == template_id
+    ).first()
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return serialize_document_template(template)
+
+
+@router.post("/", response_model=DocumentTemplateResponse)
+@limiter.limit("20/minute")
+async def create_document_template(
+    template: DocumentTemplateCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """Create a new document template (admin only)."""
+    # Check if doc_type already exists
+    existing = db.query(DocumentTemplate).filter(
+        DocumentTemplate.doc_type == template.doc_type
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Document type already exists"
+        )
+
+    # Validate LLM provider
+    valid_providers = ["openai", "anthropic", "google"]
+    if template.llm_provider not in valid_providers:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid LLM provider. Must be one of: {', '.join(valid_providers)}"
+        )
+
+    db_template = DocumentTemplate(
+        doc_type=template.doc_type,
+        display_name=template.display_name,
+        credit_cost=template.credit_cost,
+        language_source=template.language_source,
+        llm_provider=template.llm_provider,
+        llm_model=template.llm_model,
+        prompt_template=template.prompt_template,
+        is_active=template.is_active,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    db.add(db_template)
+    db.commit()
+    db.refresh(db_template)
+    logger.info(f"Admin {admin.email} created document template: {template.doc_type}")
+    return serialize_document_template(db_template)
+
+
+@router.put("/{template_id}", response_model=DocumentTemplateResponse)
+@limiter.limit("20/minute")
+async def update_document_template(
+    template_id: int,
+    template_update: DocumentTemplateUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """Update a document template (admin only)."""
+    db_template = db.query(DocumentTemplate).filter(
+        DocumentTemplate.id == template_id
+    ).first()
+    if not db_template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    # Validate LLM provider if provided
+    if template_update.llm_provider is not None:
+        valid_providers = ["openai", "anthropic", "google"]
+        if template_update.llm_provider not in valid_providers:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid LLM provider. Must be one of: {', '.join(valid_providers)}"
+            )
+
+    # Update only provided fields
+    update_data = template_update.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(db_template, field, value)
+
+    db_template.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(db_template)
+    logger.info(f"Admin {admin.email} updated document template: {db_template.doc_type}")
+    return serialize_document_template(db_template)
+
+
+@router.delete("/{template_id}")
+@limiter.limit("20/minute")
+async def delete_document_template(
+    template_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """Delete a document template (admin only)."""
+    db_template = db.query(DocumentTemplate).filter(
+        DocumentTemplate.id == template_id
+    ).first()
+    if not db_template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    doc_type = db_template.doc_type
+    db.delete(db_template)
+    db.commit()
+    logger.info(f"Admin {admin.email} deleted document template: {doc_type}")
+    return {"message": "Template deleted successfully"}
+
+
+@router.post("/seed")
+@limiter.limit("5/minute")
+async def seed_templates(
+    request: Request,
+    force_update: bool = False,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_admin_user),
+):
+    """
+    Seed document templates from catalog and prompts (admin only).
+
+    Args:
+        force_update: If True, update existing templates with new data from JSON
+    """
+    from app.seed_document_templates import seed_document_templates
+
+    result = seed_document_templates(db, force_update=force_update)
+    logger.info(f"Admin {admin.email} seeded document templates: {result}")
+    return {
+        "message": "Document templates seeded successfully",
+        **result
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from app.limiter import limiter
 
-from app.api.endpoints import documents, jobs, applications, users, admin
+from app.api.endpoints import documents, jobs, applications, users, admin, document_templates
 from app.database import init_db
 
 app = FastAPI(
@@ -47,3 +47,8 @@ app.include_router(admin.router, tags=["admin"])
 app.include_router(documents.router, prefix="/documents", tags=["documents"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(applications.router, prefix="/applications", tags=["applications"])
+app.include_router(
+    document_templates.router,
+    prefix="/admin/document-templates",
+    tags=["admin", "document-templates"]
+)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -175,3 +175,31 @@ class PromptTemplate(Base):
     name = Column(String, nullable=False)
     content = Column(Text, nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
+class DocumentTemplate(Base):
+    __tablename__ = "document_templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    doc_type = Column(String, unique=True, nullable=False)  # e.g. "tailored_cv_pdf"
+    display_name = Column(String, nullable=False)  # e.g. "Tailored CV (PDF)"
+    credit_cost = Column(Integer, default=1, nullable=False)  # 0-10
+
+    # Language configuration
+    language_source = Column(String, default="documentation_language", nullable=False)
+    # Options: "preferred_language", "mother_tongue", "documentation_language"
+
+    # LLM configuration
+    llm_provider = Column(String, default="openai", nullable=False)
+    # Options: "openai", "anthropic", "google"
+    llm_model = Column(String, default="gpt-4", nullable=False)
+    # e.g. "gpt-4", "gpt-3.5-turbo", "claude-3-sonnet-20240229", "gemini-pro"
+
+    # Prompt template with {language} placeholder
+    prompt_template = Column(Text, nullable=False)
+
+    # Status
+    is_active = Column(Boolean, default=True)
+
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/backend/app/seed_document_templates.py
+++ b/backend/app/seed_document_templates.py
@@ -1,0 +1,155 @@
+"""Seed script to populate document_templates table from document_catalog and document_prompts.
+
+Usage:
+    cd backend
+    python -m app.seed_document_templates
+"""
+import json
+import os
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal, init_db
+from app.models import DocumentTemplate
+from app.document_catalog import ESSENTIAL_PACK, HIGH_IMPACT_ADDONS, PREMIUM_DOCUMENTS
+
+
+def load_prompts() -> dict:
+    """Load prompt templates from JSON file."""
+    prompts_file = os.path.join(os.path.dirname(__file__), "document_prompts.json")
+    with open(prompts_file, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_all_document_types() -> list:
+    """Get all document types from catalog with display names."""
+    all_docs = []
+    for doc in ESSENTIAL_PACK:
+        all_docs.append({
+            "key": doc["key"],
+            "title": doc["title"],
+            "category": "essential_pack"
+        })
+    for doc in HIGH_IMPACT_ADDONS:
+        all_docs.append({
+            "key": doc["key"],
+            "title": doc["title"],
+            "category": "high_impact_addons"
+        })
+    for doc in PREMIUM_DOCUMENTS:
+        all_docs.append({
+            "key": doc["key"],
+            "title": doc["title"],
+            "category": "premium_documents"
+        })
+    return all_docs
+
+
+def seed_document_templates(db: Session, force_update: bool = False) -> dict:
+    """
+    Seed document templates from catalog and prompts.
+
+    Args:
+        db: Database session
+        force_update: If True, update existing templates with new data
+
+    Returns:
+        dict with counts of created, updated, and skipped templates
+    """
+    prompts = load_prompts()
+    doc_types = get_all_document_types()
+
+    created = 0
+    updated = 0
+    skipped = 0
+
+    for doc in doc_types:
+        doc_key = doc["key"]
+        display_name = doc["title"]
+
+        # Get prompt template from JSON
+        prompt_config = prompts.get(doc_key, {})
+        prompt_template_text = prompt_config.get("prompt_template", "")
+
+        if not prompt_template_text:
+            print(f"Warning: No prompt template found for {doc_key}, skipping...")
+            skipped += 1
+            continue
+
+        # Check if template already exists
+        existing = db.query(DocumentTemplate).filter(
+            DocumentTemplate.doc_type == doc_key
+        ).first()
+
+        if existing:
+            if force_update:
+                # Update existing template
+                existing.display_name = display_name
+                existing.prompt_template = prompt_template_text
+                existing.updated_at = datetime.now(timezone.utc)
+                updated += 1
+                print(f"Updated: {doc_key}")
+            else:
+                skipped += 1
+                print(f"Skipped (exists): {doc_key}")
+            continue
+
+        # Create new template
+        template = DocumentTemplate(
+            doc_type=doc_key,
+            display_name=display_name,
+            credit_cost=1,  # Default cost
+            language_source="documentation_language",  # Default language source
+            llm_provider="openai",  # Default provider
+            llm_model="gpt-4",  # Default model
+            prompt_template=prompt_template_text,
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(template)
+        created += 1
+        print(f"Created: {doc_key}")
+
+    db.commit()
+
+    return {
+        "created": created,
+        "updated": updated,
+        "skipped": skipped,
+        "total": len(doc_types)
+    }
+
+
+def main():
+    """Main entry point for seed script."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Seed document templates from catalog and prompts")
+    parser.add_argument(
+        "--force-update",
+        action="store_true",
+        help="Update existing templates with new data from JSON"
+    )
+    args = parser.parse_args()
+
+    # Initialize database
+    init_db()
+
+    # Create session and seed data
+    db = SessionLocal()
+    try:
+        print("Seeding document templates...")
+        result = seed_document_templates(db, force_update=args.force_update)
+        print(f"\nSeed complete:")
+        print(f"  Created: {result['created']}")
+        print(f"  Updated: {result['updated']}")
+        print(f"  Skipped: {result['skipped']}")
+        print(f"  Total: {result['total']}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/migrations/versions/20251204_02_add_document_templates.py
+++ b/backend/migrations/versions/20251204_02_add_document_templates.py
@@ -1,0 +1,54 @@
+"""Add document_templates table for configurable document generation.
+
+Revision ID: 20251204_02
+Revises: 20251204_01
+Create Date: 2025-12-04
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "20251204_02"
+down_revision = "20251204_01"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(inspector, table_name: str) -> bool:
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Create document_templates table
+    if not _table_exists(inspector, "document_templates"):
+        op.create_table(
+            "document_templates",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("doc_type", sa.String(), nullable=False),
+            sa.Column("display_name", sa.String(), nullable=False),
+            sa.Column("credit_cost", sa.Integer(), server_default="1", nullable=False),
+            sa.Column("language_source", sa.String(), server_default="documentation_language", nullable=False),
+            sa.Column("llm_provider", sa.String(), server_default="openai", nullable=False),
+            sa.Column("llm_model", sa.String(), server_default="gpt-4", nullable=False),
+            sa.Column("prompt_template", sa.Text(), nullable=False),
+            sa.Column("is_active", sa.Boolean(), server_default="1", nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("doc_type"),
+        )
+        op.create_index("ix_document_templates_id", "document_templates", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    # Drop document_templates table
+    if _table_exists(inspector, "document_templates"):
+        op.drop_index("ix_document_templates_id", table_name="document_templates")
+        op.drop_table("document_templates")

--- a/frontend/app/admin/documents/page.tsx
+++ b/frontend/app/admin/documents/page.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAuth } from "@/lib/auth-context";
+import { useRouter } from "next/navigation";
+import api, { DocumentTemplate, DocumentTemplateUpdate } from "@/lib/api";
+import { Card } from "@/components/Card";
+import { Button } from "@/components/Button";
+
+export default function AdminDocumentsPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [templates, setTemplates] = useState<DocumentTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<DocumentTemplateUpdate>({});
+  const [expandedPrompt, setExpandedPrompt] = useState<number | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [seeding, setSeeding] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && (!user || !user.is_admin)) {
+      router.push("/dashboard");
+    }
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (user?.is_admin) {
+      loadTemplates();
+    }
+  }, [user]);
+
+  const loadTemplates = async () => {
+    try {
+      const data = await api.getDocumentTemplates();
+      setTemplates(data);
+    } catch (error) {
+      console.error("Failed to load templates:", error);
+      setStatus("Fehler beim Laden der Templates.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const startEdit = (template: DocumentTemplate) => {
+    setEditingId(template.id);
+    setEditForm({
+      display_name: template.display_name,
+      credit_cost: template.credit_cost,
+      language_source: template.language_source,
+      llm_provider: template.llm_provider,
+      llm_model: template.llm_model,
+      prompt_template: template.prompt_template,
+      is_active: template.is_active,
+    });
+  };
+
+  const saveEdit = async (id: number) => {
+    try {
+      await api.updateDocumentTemplate(id, editForm);
+      await loadTemplates();
+      setEditingId(null);
+      setEditForm({});
+      setStatus("Template erfolgreich aktualisiert.");
+    } catch (error) {
+      console.error("Failed to update template:", error);
+      setStatus("Fehler beim Aktualisieren des Templates.");
+    }
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditForm({});
+  };
+
+  const handleSeed = async (forceUpdate: boolean = false) => {
+    setSeeding(true);
+    try {
+      const result = await api.seedDocumentTemplates(forceUpdate);
+      setStatus(`Seed abgeschlossen: ${result.created} erstellt, ${result.updated} aktualisiert, ${result.skipped} übersprungen.`);
+      await loadTemplates();
+    } catch (error) {
+      console.error("Failed to seed templates:", error);
+      setStatus("Fehler beim Seeden der Templates.");
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return <div className="p-8 text-gray-700 dark:text-gray-200">Lade...</div>;
+  }
+
+  if (!user?.is_admin) {
+    return null;
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Document Templates Admin</h1>
+        <Button onClick={() => router.push("/admin")} variant="outline">
+          Zurück zu Admin
+        </Button>
+      </div>
+
+      {status && (
+        <div className="rounded bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300 px-4 py-2 text-sm" role="status">
+          {status}
+        </div>
+      )}
+
+      <Card>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+              Dokumenten-Templates konfigurieren
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
+              Verwalte Credit-Kosten, Sprachquellen, LLM Provider und Prompts für jeden Dokumenttyp.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={() => handleSeed(false)} disabled={seeding} variant="outline">
+              {seeding ? "Seeding..." : "Seed Templates"}
+            </Button>
+            <Button onClick={() => handleSeed(true)} disabled={seeding} variant="outline">
+              {seeding ? "Seeding..." : "Force Update"}
+            </Button>
+          </div>
+        </div>
+
+        {templates.length === 0 ? (
+          <div className="text-center py-8 text-gray-500">
+            <p>Keine Templates gefunden.</p>
+            <p className="text-sm mt-2">Klicke auf "Seed Templates" um die Templates aus dem Katalog zu laden.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-700">
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Dokumenttyp</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Credits</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Sprachquelle</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">LLM Provider</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Modell</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Prompt</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Aktiv</th>
+                  <th className="text-left p-3 font-semibold text-gray-900 dark:text-gray-100">Aktionen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {templates.map((template) => {
+                  const isEditing = editingId === template.id;
+                  const isExpanded = expandedPrompt === template.id;
+
+                  return (
+                    <tr key={template.id} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                      <td className="p-3">
+                        <div className="font-semibold text-gray-900 dark:text-gray-100">{template.doc_type}</div>
+                        {isEditing ? (
+                          <input
+                            type="text"
+                            value={editForm.display_name || ""}
+                            onChange={(e) => setEditForm({ ...editForm, display_name: e.target.value })}
+                            className="mt-1 w-full rounded border border-gray-300 dark:border-gray-600 px-2 py-1 text-sm bg-white dark:bg-gray-800"
+                          />
+                        ) : (
+                          <div className="text-xs text-gray-500 dark:text-gray-400">{template.display_name}</div>
+                        )}
+                      </td>
+
+                      {/* Credit Cost */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <input
+                            type="number"
+                            min="0"
+                            max="10"
+                            value={editForm.credit_cost ?? 1}
+                            onChange={(e) => setEditForm({ ...editForm, credit_cost: parseInt(e.target.value) })}
+                            className="w-16 rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-800"
+                          />
+                        ) : (
+                          <span className="font-mono">{template.credit_cost}</span>
+                        )}
+                      </td>
+
+                      {/* Language Source */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <select
+                            value={editForm.language_source || "documentation_language"}
+                            onChange={(e) => setEditForm({ ...editForm, language_source: e.target.value as DocumentTemplateUpdate["language_source"] })}
+                            className="rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-800"
+                          >
+                            <option value="preferred_language">Preferred Language</option>
+                            <option value="mother_tongue">Mother Tongue</option>
+                            <option value="documentation_language">Documentation Language</option>
+                          </select>
+                        ) : (
+                          <span className="text-xs">{template.language_source.replace(/_/g, " ")}</span>
+                        )}
+                      </td>
+
+                      {/* LLM Provider */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <select
+                            value={editForm.llm_provider || "openai"}
+                            onChange={(e) => setEditForm({ ...editForm, llm_provider: e.target.value })}
+                            className="rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-800"
+                          >
+                            <option value="openai">OpenAI</option>
+                            <option value="anthropic">Anthropic (Claude)</option>
+                            <option value="google">Google (Gemini)</option>
+                          </select>
+                        ) : (
+                          <span className="capitalize">{template.llm_provider}</span>
+                        )}
+                      </td>
+
+                      {/* LLM Model */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <input
+                            type="text"
+                            value={editForm.llm_model || ""}
+                            onChange={(e) => setEditForm({ ...editForm, llm_model: e.target.value })}
+                            className="w-full rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-800"
+                            placeholder="z.B. gpt-4"
+                          />
+                        ) : (
+                          <span className="font-mono text-xs">{template.llm_model}</span>
+                        )}
+                      </td>
+
+                      {/* Prompt */}
+                      <td className="p-3 max-w-xs">
+                        {isEditing ? (
+                          <textarea
+                            value={editForm.prompt_template || ""}
+                            onChange={(e) => setEditForm({ ...editForm, prompt_template: e.target.value })}
+                            className="w-full rounded border border-gray-300 dark:border-gray-600 px-2 py-1 bg-white dark:bg-gray-800 text-xs"
+                            rows={6}
+                            placeholder="Prompt template mit {language} placeholder"
+                          />
+                        ) : (
+                          <div>
+                            <button
+                              onClick={() => setExpandedPrompt(isExpanded ? null : template.id)}
+                              className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-xs underline"
+                            >
+                              {isExpanded ? "Verbergen" : "Anzeigen"}
+                            </button>
+                            {isExpanded && (
+                              <pre className="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded text-xs overflow-auto max-h-60 whitespace-pre-wrap">
+                                {template.prompt_template}
+                              </pre>
+                            )}
+                          </div>
+                        )}
+                      </td>
+
+                      {/* Active Status */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <input
+                            type="checkbox"
+                            checked={editForm.is_active ?? true}
+                            onChange={(e) => setEditForm({ ...editForm, is_active: e.target.checked })}
+                            className="w-4 h-4 rounded"
+                          />
+                        ) : (
+                          <span className={template.is_active ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}>
+                            {template.is_active ? "Ja" : "Nein"}
+                          </span>
+                        )}
+                      </td>
+
+                      {/* Actions */}
+                      <td className="p-3">
+                        {isEditing ? (
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => saveEdit(template.id)}
+                              className="px-3 py-1 rounded bg-green-600 text-white text-xs hover:bg-green-700"
+                            >
+                              Speichern
+                            </button>
+                            <button
+                              onClick={cancelEdit}
+                              className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs hover:bg-gray-300 dark:hover:bg-gray-600"
+                            >
+                              Abbrechen
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => startEdit(template)}
+                            className="px-3 py-1 rounded bg-blue-600 text-white text-xs hover:bg-blue-700"
+                          >
+                            Bearbeiten
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {/* Help Section */}
+      <Card>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">Hilfe</h3>
+        <div className="space-y-3 text-sm text-gray-600 dark:text-gray-400">
+          <div>
+            <strong className="text-gray-900 dark:text-gray-100">Credits:</strong> Kosten pro Dokumentgenerierung (0-10). 0 = kostenlos.
+          </div>
+          <div>
+            <strong className="text-gray-900 dark:text-gray-100">Sprachquelle:</strong> Welches Benutzer-Sprachfeld für die Dokumentgenerierung verwendet wird.
+            <ul className="list-disc ml-5 mt-1">
+              <li><code>preferred_language</code> - Bevorzugte Sprache des Benutzers</li>
+              <li><code>mother_tongue</code> - Muttersprache des Benutzers</li>
+              <li><code>documentation_language</code> - Dokumentationssprache (Standard)</li>
+            </ul>
+          </div>
+          <div>
+            <strong className="text-gray-900 dark:text-gray-100">LLM Provider:</strong> Der KI-Anbieter für die Generierung.
+            <ul className="list-disc ml-5 mt-1">
+              <li><code>openai</code> - OpenAI (GPT-4, etc.)</li>
+              <li><code>anthropic</code> - Anthropic (Claude)</li>
+              <li><code>google</code> - Google (Gemini)</li>
+            </ul>
+          </div>
+          <div>
+            <strong className="text-gray-900 dark:text-gray-100">Prompt Template:</strong> Der Prompt für die LLM-Generierung.
+            Verwende <code>{"{language}"}</code> als Platzhalter für die dynamische Sprache.
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import api, {
   ActivityEntry,
   AdminLanguageSetting,
@@ -23,6 +24,7 @@ function SectionCard({ title, children }: { title: string; children: React.React
 
 export default function AdminPage() {
   const { user, loading } = useAuth();
+  const router = useRouter();
   const [languages, setLanguages] = useState<AdminLanguageSetting[]>([]);
   const [users, setUsers] = useState<AdminUserSummary[]>([]);
   const [selectedUser, setSelectedUser] = useState<AdminUserDetail | null>(null);
@@ -184,6 +186,19 @@ export default function AdminPage() {
           {status}
         </div>
       )}
+
+      {/* Document Templates Navigation Card */}
+      <SectionCard title="Document Templates">
+        <p className="text-gray-600 dark:text-gray-400 mb-4">
+          Konfiguriere Credit-Kosten, Sprachquellen, LLM Provider und Prompts für die Dokumentgenerierung.
+        </p>
+        <button
+          onClick={() => router.push("/admin/documents")}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Document Templates verwalten
+        </button>
+      </SectionCard>
 
       <SectionCard title="Sprachen verwalten">
         <div className="space-y-2">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -120,6 +120,30 @@ export interface PromptTemplate {
   updated_at: string;
 }
 
+export interface DocumentTemplate {
+  id: number;
+  doc_type: string;
+  display_name: string;
+  credit_cost: number;
+  language_source: 'preferred_language' | 'mother_tongue' | 'documentation_language';
+  llm_provider: string;
+  llm_model: string;
+  prompt_template: string;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface DocumentTemplateUpdate {
+  display_name?: string;
+  credit_cost?: number;
+  language_source?: 'preferred_language' | 'mother_tongue' | 'documentation_language';
+  llm_provider?: string;
+  llm_model?: string;
+  prompt_template?: string;
+  is_active?: boolean;
+}
+
 class ApiClient {
   private baseUrl: string;
   private token: string | null = null;
@@ -468,6 +492,36 @@ class ApiClient {
       method: "PUT",
       body: JSON.stringify({ name, content }),
     });
+  }
+
+  // Document Template endpoints
+  async getDocumentTemplates() {
+    return this.request<DocumentTemplate[]>("/admin/document-templates/");
+  }
+
+  async getDocumentTemplate(id: number) {
+    return this.request<DocumentTemplate>(`/admin/document-templates/${id}`);
+  }
+
+  async updateDocumentTemplate(id: number, data: DocumentTemplateUpdate) {
+    return this.request<DocumentTemplate>(`/admin/document-templates/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteDocumentTemplate(id: number) {
+    return this.request<{ message: string }>(`/admin/document-templates/${id}`, {
+      method: "DELETE",
+    });
+  }
+
+  async seedDocumentTemplates(forceUpdate: boolean = false) {
+    const params = forceUpdate ? "?force_update=true" : "";
+    return this.request<{ message: string; created: number; updated: number; skipped: number; total: number }>(
+      `/admin/document-templates/seed${params}`,
+      { method: "POST" }
+    );
   }
 
   async downloadJobDescriptionPDF(applicationId: number) {


### PR DESCRIPTION
Implements configurable document templates for controlling:
- Credit costs per document (0-10)
- Language source (preferred_language, mother_tongue, documentation_language)
- LLM provider (openai, anthropic, google) and model selection
- Prompt templates with {language} placeholder

Backend changes:
- Add DocumentTemplate model in models.py
- Add Alembic migration for document_templates table
- Add seed script to populate templates from document_catalog and prompts
- Add API endpoints for CRUD operations on templates
- Update document generation to use template configuration

Frontend changes:
- Add DocumentTemplate types and API methods
- Add admin documents page at /admin/documents
- Add navigation link from main admin page