### PR TITLE
fix: prevent mobile header overflow while keeping app name visible

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -94,7 +94,7 @@ export default function Home() {
             <img src="/logo.png" alt="EasyBewerbung" className="w-8 h-8 rounded-lg flex-shrink-0" />
             <span className="text-lg sm:text-xl font-bold whitespace-nowrap">{t("common.appName")}</span>
           </div>
-          <div className="flex gap-2 sm:gap-3 items-center flex-shrink-0">
+          <div className="flex gap-2 sm:gap-3 items-center">
             <button
               type="button"
               onClick={toggleTheme}


### PR DESCRIPTION
### Summary

Fixed the mobile layout overflow issue where the right edge of the header was extending beyond the screen.

### Changes

- Removed `flex-shrink-0` from the button container on the right side of the header
- Kept `flex-shrink-0` on the logo/name container to prevent "EasyBewerbung" from being truncated
- This allows the button container to shrink naturally on mobile while keeping the app name fully visible

The header now fits properly on mobile screens without horizontal overflow, while "EasyBewerbung" remains fully visible.

Fixes #51

---

Generated with [Claude Code](https://claude.ai/code)