### PR TITLE
Fix right edge overflow on mobile viewport

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -86,8 +86,19 @@ body {
   overflow-x: hidden;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 * {
   max-width: 100%;
+  box-sizing: border-box;
+}
+
+/* Ensure text never extends beyond viewport */
+h1, h2, h3, h4, h5, h6, p, span, div, section, header, footer {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .page-shell {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -90,15 +90,15 @@ export default function Home() {
       {/* Header */}
       <header className="border-b border-muted backdrop-blur nav-surface">
         <div className="container mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 flex-shrink-0 min-w-0">
             <img src="/logo.png" alt="EasyBewerbung" className="w-8 h-8 rounded-lg flex-shrink-0" />
             <span className="text-lg sm:text-xl font-bold whitespace-nowrap">{t("common.appName")}</span>
           </div>
-          <div className="flex gap-1.5 sm:gap-2 md:gap-3 items-center flex-shrink-0">
+          <div className="flex gap-1.5 sm:gap-2 md:gap-3 items-center flex-shrink-0 min-w-0">
             <button
               type="button"
               onClick={toggleTheme}
-              className="btn-base btn-secondary flex items-center gap-1 sm:gap-2 px-2 sm:px-4"
+              className="btn-base btn-secondary flex items-center gap-1 sm:gap-2 px-2 sm:px-4 flex-shrink-0"
               aria-pressed={theme === "light"}
             >
               <span aria-hidden>{theme === "light" ? "🌙" : "☀️"}</span>
@@ -107,17 +107,18 @@ export default function Home() {
               </span>
             </button>
             {/* Language selector - compact on mobile, full on desktop */}
-            <div className="relative flex items-center">
+            <div className="relative flex items-center flex-shrink-0 min-w-0">
               <label className="text-sm text-muted mr-2 hidden lg:inline">{t("common.language")}:</label>
               <select
                 value={locale}
                 onChange={(e) => handleLanguageChange(e.target.value)}
-                className="px-2 sm:px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2"
+                className="px-2 sm:px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 max-w-full"
                 style={{
                   background: "var(--card-background)",
                   color: "var(--foreground)",
                   borderColor: "var(--border)",
                   boxShadow: "none",
+                  minWidth: "0",
                 }}
                 aria-label={t("common.language")}
               >
@@ -142,19 +143,19 @@ export default function Home() {
       {/* Hero Section */}
       <section className="container mx-auto px-6 py-20 text-center">
         <div className="max-w-3xl mx-auto space-y-6">
-          <h1 className="text-5xl font-bold leading-tight">
+          <h1 className="text-4xl sm:text-5xl font-bold leading-tight break-words">
             {t("home.title")}{" "}
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">
               {t("home.titleHighlight")}
             </span>
           </h1>
-          <p className="text-xl text-muted">
+          <p className="text-lg sm:text-xl text-muted break-words">
             {t("home.subtitle")}
           </p>
-          <p className="text-lg text-success">
+          <p className="text-base sm:text-lg text-success break-words">
             {t("home.availableLanguages")}
           </p>
-          <div className="flex gap-4 justify-center pt-4">
+          <div className="flex flex-wrap gap-4 justify-center pt-4">
             <Button href="/register" variant="primary">
               {t("home.startFree")} →
             </Button>
@@ -167,15 +168,15 @@ export default function Home() {
 
       {/* Features */}
       <section id="features" className="container mx-auto px-6 py-16">
-        <h2 className="text-3xl font-bold text-center mb-12">
+        <h2 className="text-2xl sm:text-3xl font-bold text-center mb-12 break-words">
           {t("home.howItWorks")}
         </h2>
         <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
           {features.map((feature, index) => (
             <Card key={index}>
               <div className="text-4xl mb-4">{feature.icon}</div>
-              <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
-              <p className="text-muted">{feature.description}</p>
+              <h3 className="text-lg sm:text-xl font-semibold mb-2 break-words">{feature.title}</h3>
+              <p className="text-muted break-words">{feature.description}</p>
             </Card>
           ))}
         </div>
@@ -184,18 +185,18 @@ export default function Home() {
       {/* Languages Section */}
       <section className="container mx-auto px-6 py-16">
         <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-8">
+          <h2 className="text-2xl sm:text-3xl font-bold text-center mb-8 break-words">
             {t("home.languageSection")}
           </h2>
           <Card>
-            <p className="text-muted text-center mb-6">
+            <p className="text-muted text-center mb-6 break-words">
               {t("home.languageDescription")}
             </p>
             <div className="flex flex-wrap gap-2 justify-center">
               {languages.map((lang, index) => (
                 <span
                   key={index}
-                  className="chip px-3 py-1 rounded-full text-sm"
+                  className="chip px-3 py-1 rounded-full text-sm break-words"
                 >
                   {lang}
                 </span>
@@ -209,10 +210,10 @@ export default function Home() {
       <section className="container mx-auto px-6 py-16">
         <div className="max-w-2xl mx-auto text-center">
           <Card className="border-2" style={{ borderColor: "var(--success)" }}>
-            <h2 className="text-2xl font-bold mb-4 text-success">
+            <h2 className="text-xl sm:text-2xl font-bold mb-4 text-success break-words">
               🇨🇭 {t("home.ravTitle")}
             </h2>
-            <p className="text-muted">
+            <p className="text-muted break-words">
               {t("home.ravDescription")}
             </p>
           </Card>
@@ -222,13 +223,13 @@ export default function Home() {
       {/* CTA Section */}
       <section className="container mx-auto px-6 py-20">
         <div className="max-w-2xl mx-auto text-center space-y-6">
-          <h2 className="text-4xl font-bold">
+          <h2 className="text-3xl sm:text-4xl font-bold break-words">
             {t("home.ctaTitle")}
           </h2>
-          <p className="text-xl text-muted">
+          <p className="text-lg sm:text-xl text-muted break-words">
             {t("home.ctaSubtitle")}
           </p>
-          <Button href="/register" variant="primary" className="text-lg">
+          <Button href="/register" variant="primary" className="text-base sm:text-lg">
             {t("home.createAccount")} →
           </Button>
         </div>
@@ -237,7 +238,7 @@ export default function Home() {
       {/* Footer */}
       <footer className="border-t border-muted py-8 text-muted">
         <div className="container mx-auto px-6 text-center">
-          <p>© 2025 {t("common.appName")}. {t("home.footer")}</p>
+          <p className="break-words">© 2025 {t("common.appName")}. {t("home.footer")}</p>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Fixes #59

This PR addresses the right edge overflow issue where content was extending beyond the viewport boundary on mobile devices.

## Changes
- Fixed header language selector overflow with proper flex constraints
- Implemented responsive text sizing across all sections
- Added word-breaking classes to prevent text overflow
- Added global CSS rules for comprehensive overflow protection

Generated with [Claude Code](https://claude.ai/code)