### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/backend/app/api/endpoints/jobs.py
+++ b/backend/app/api/endpoints/jobs.py
@@ -123,12 +123,12 @@ def sanitize_html_text(text: str) -> str:
     Removes any remaining HTML tags and dangerous characters.
     """
     # First, remove dangerous tags with their content (order matters!)
-    # Handle whitespace in closing tags: </script>, </script >, </script  >, etc.
-    text = re.sub(r'<script[^>]*>.*?</script\s*>', '', text, flags=re.DOTALL | re.IGNORECASE)
-    text = re.sub(r'<style[^>]*>.*?</style\s*>', '', text, flags=re.DOTALL | re.IGNORECASE)
-    text = re.sub(r'<iframe[^>]*>.*?</iframe\s*>', '', text, flags=re.DOTALL | re.IGNORECASE)
-    text = re.sub(r'<object[^>]*>.*?</object\s*>', '', text, flags=re.DOTALL | re.IGNORECASE)
-    text = re.sub(r'<embed[^>]*>.*?</embed\s*>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    # Handle flexible/invalid closing tags: </script>, </script >, </script\t foo="bar">, etc.
+    text = re.sub(r'<script[^>]*>.*?</script[^>]*>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<style[^>]*>.*?</style[^>]*>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<iframe[^>]*>.*?</iframe[^>]*>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<object[^>]*>.*?</object[^>]*>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<embed[^>]*>.*?</embed[^>]*>', '', text, flags=re.DOTALL | re.IGNORECASE)
 
     # Remove self-closing dangerous tags (e.g., <embed />, <iframe/>)
     text = re.sub(r'<(script|style|iframe|object|embed)[^>]*/\s*>', '', text, flags=re.IGNORECASE)


### PR DESCRIPTION
Potential fix for [https://github.com/XelaG155/EasyBewerbung/security/code-scanning/3](https://github.com/XelaG155/EasyBewerbung/security/code-scanning/3)

In general, the right fix is to stop relying on brittle ad‑hoc regexes for HTML and instead use a trusted parser/sanitizer library. However, given the constraint to only modify the shown snippet, the best we can do is to adjust the regex so it better matches the range of closing tag forms that browsers accept while preserving existing behavior.

The specific issue is the closing part of patterns like `</script\s*>`. We can broaden them to accept any characters up to the next `>` instead of only optional spaces. For example, use `</script[^>]*>` rather than `</script\s*>`. This will correctly match `</script>`, `</script >`, `</script\t\n foo="bar">`, etc. We should apply this change consistently to all the “dangerous tag with content” patterns (script, style, iframe, object, embed). The first capturing part (`<script[^>]*>`) remains unchanged; we just modify the closing tag portion.

Concretely, in `backend/app/api/endpoints/jobs.py` inside `sanitize_html_text`, change:

- Line 127: `<script[^>]*>.*?</script\s*>` → `<script[^>]*>.*?</script[^>]*>`
- Line 128: `<style[^>]*>.*?</style\s*>` → `<style[^>]*>.*?</style[^>]*>`
- Line 129: `<iframe[^>]*>.*?</iframe\s*>` → `<iframe[^>]*>.*?</iframe[^>]*>`
- Line 130: `<object[^>]*>.*?</object\s*>` → `<object[^>]*>.*?</object[^>]*>`
- Line 131: `<embed[^>]*>.*?</embed\s*>` → `<embed[^>]*>.*?</embed[^>]*>`

No new imports or methods are needed; we continue to use `re.sub` with the same flags and semantics.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
